### PR TITLE
Fix CI lint and type failures

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -165,9 +165,7 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
         )
         if is_priced(model):
             try:
-                task_ids = (
-                    load_suite(suite).task_ids if suite is not None else [task]  # type: ignore[list-item]
-                )
+                task_ids = _selected_task_ids(task, suite)
                 plan = estimate_plan(
                     models=[model],
                     task_ids=task_ids,
@@ -273,6 +271,14 @@ def _print_cost_estimate(plan: Any, *, json_output: bool = False) -> None:
     )
 
 
+def _selected_task_ids(task: str | None, suite: str | None) -> list[str]:
+    if suite is not None:
+        return load_suite(suite).task_ids
+    if task is None:
+        raise ValueError("task required when suite is not provided")
+    return [task]
+
+
 @app.command()
 def estimate(
     task: str | None = typer.Option(None, "--task", "-t", help="Single task ID"),
@@ -306,7 +312,7 @@ def estimate(
         raise typer.Exit(code=1)
 
     try:
-        task_ids = load_suite(suite).task_ids if suite is not None else [task]  # type: ignore[list-item]
+        task_ids = _selected_task_ids(task, suite)
         plan = estimate_plan(
             models=model,
             task_ids=task_ids,

--- a/harness/cost_estimate.py
+++ b/harness/cost_estimate.py
@@ -49,9 +49,7 @@ _PROVIDER_LABEL = {
 }
 
 _KNOWN_TASK_SOURCES = frozenset({"exact", "prior_exact"})
-_PRIOR_SOURCES = frozenset(
-    {"prior_exact", "prior_task_scaled", "prior_model_median"}
-)
+_PRIOR_SOURCES = frozenset({"prior_exact", "prior_task_scaled", "prior_model_median"})
 
 
 @dataclass
@@ -249,7 +247,9 @@ class _CostIndex:
             return _DEFAULT_PER_RUN[prefix]
         return _DEFAULT_FALLBACK
 
-    def estimate_one(self, model: str, task_id: str, tasks_root: Path) -> RunCostEstimate:
+    def estimate_one(  # noqa: PLR0911 — ordered fallback chain for estimate sources
+        self, model: str, task_id: str, tasks_root: Path
+    ) -> RunCostEstimate:
         direct = self.by_model_task.get((model, task_id))
         if direct:
             return RunCostEstimate(
@@ -272,9 +272,7 @@ class _CostIndex:
             return scaled_local
 
         prior_task_entries = [
-            (m, p.mid)
-            for (m, t), p in self.priors.by_model_task.items()
-            if t == task_id
+            (m, p.mid) for (m, t), p in self.priors.by_model_task.items() if t == task_id
         ]
         scaled_prior = _task_scaled_estimate(
             task_id, model, prior_task_entries, "prior_task_scaled"
@@ -321,7 +319,7 @@ def _task_judge_mult(judges: bool, source: str, priors: PriorBuckets) -> float:
     return 3.0 if judges else 1.0
 
 
-def estimate_plan(
+def estimate_plan(  # noqa: PLR0912 — validation + confidence calculation stay linear
     *,
     models: list[str],
     task_ids: list[str],
@@ -368,24 +366,15 @@ def estimate_plan(
             confidence = "medium"
 
         low = round(
-            sum(
-                t.low_usd * _task_judge_mult(judges, t.source, priors) for t in per_task
-            )
-            * repeat,
+            sum(t.low_usd * _task_judge_mult(judges, t.source, priors) for t in per_task) * repeat,
             4,
         )
         mid = round(
-            sum(
-                t.mid_usd * _task_judge_mult(judges, t.source, priors) for t in per_task
-            )
-            * repeat,
+            sum(t.mid_usd * _task_judge_mult(judges, t.source, priors) for t in per_task) * repeat,
             4,
         )
         high = round(
-            sum(
-                t.high_usd * _task_judge_mult(judges, t.source, priors) for t in per_task
-            )
-            * repeat,
+            sum(t.high_usd * _task_judge_mult(judges, t.source, priors) for t in per_task) * repeat,
             4,
         )
         recommended = round(high * credit_buffer, 2)
@@ -395,8 +384,7 @@ def estimate_plan(
             notes.append("Includes ~3x agent-token judge ensemble (--judges).")
         if n_prior_exact > 0 and n_local_exact == 0:
             notes.append(
-                f"Using bundled cost priors (no local ./runs history for "
-                f"{n_prior_exact} task(s))."
+                f"Using bundled cost priors (no local ./runs history for {n_prior_exact} task(s))."
             )
         elif n_prior_only > 0:
             notes.append(f"Partial bundled priors for {n_prior_only} task(s).")

--- a/harness/cost_priors.py
+++ b/harness/cost_priors.py
@@ -46,14 +46,18 @@ def _parse_range(raw: Any) -> PriorRange | None:
     low = raw.get("low")
     mid = raw.get("mid")
     high = raw.get("high")
-    if not all(isinstance(v, (int, float)) for v in (low, mid, high)):
+    if not isinstance(low, (int, float)):
+        return None
+    if not isinstance(mid, (int, float)):
+        return None
+    if not isinstance(high, (int, float)):
         return None
     n = raw.get("n", 0)
     n_int = int(n) if isinstance(n, (int, float)) else 0
     return PriorRange(low=float(low), mid=float(mid), high=float(high), n=n_int)
 
 
-def _parse_priors(data: Any) -> PriorBuckets:
+def _parse_priors(data: Any) -> PriorBuckets:  # noqa: PLR0912 — JSON shape validation is linear
     if not isinstance(data, dict):
         return PriorBuckets.empty()
     if data.get("version") != 1:

--- a/harness/validate.py
+++ b/harness/validate.py
@@ -249,8 +249,7 @@ def validate_task(task_root: Path, opts: ValidateOptions | None = None) -> Resul
                 return Result(task_id, FAIL, [f"nondeterministic gold scores: {sorted(scores)}"])
             mode = "docker" if opts.sandbox == "docker" else "local"
             r.reasons.append(
-                f"gold=1.0, pre-patch={base}, deterministic over {DETERMINISM_RUNS} runs "
-                f"({mode})"
+                f"gold=1.0, pre-patch={base}, deterministic over {DETERMINISM_RUNS} runs ({mode})"
             )
     except (RuntimeError, AssertionError) as e:
         return Result(task_id, FAIL, [str(e)])

--- a/scripts/export_cost_priors.py
+++ b/scripts/export_cost_priors.py
@@ -94,15 +94,13 @@ def export_priors(
     out_mt: dict[str, dict[str, dict[str, float | int]]] = {}
     for model in sorted(by_model_task):
         out_mt[model] = {
-            task_id: _bucket_stats(costs)
-            for task_id, costs in sorted(by_model_task[model].items())
+            task_id: _bucket_stats(costs) for task_id, costs in sorted(by_model_task[model].items())
         }
 
     out_ms: dict[str, dict[str, dict[str, float | int]]] = {}
     for model in sorted(by_model_scale):
         out_ms[model] = {
-            scale: _bucket_stats(costs)
-            for scale, costs in sorted(by_model_scale[model].items())
+            scale: _bucket_stats(costs) for scale, costs in sorted(by_model_scale[model].items())
         }
 
     return {
@@ -168,7 +166,7 @@ def main(argv: list[str] | None = None) -> int:
     args.output.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     print(
         f"wrote {args.output} "
-        f"({n_task_buckets} model×task, {n_scale_buckets} model×scale buckets)"
+        f"({n_task_buckets} model x task, {n_scale_buckets} model x scale buckets)"
     )
     return 0
 

--- a/tests/test_cost_estimate.py
+++ b/tests/test_cost_estimate.py
@@ -95,7 +95,9 @@ def test_estimate_judges_multiplier(tmp_path: Path) -> None:
     assert on.mid_usd == pytest.approx(off.mid_usd * 3)
 
 
-def test_estimate_bundled_priors_cold_start(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_estimate_bundled_priors_cold_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runs = tmp_path / "runs"
     monkeypatch.setenv("VULCANBENCH_COST_PRIORS", str(_FIXTURE_PRIORS))
     reset_cache()

--- a/tests/test_validate_tasks.py
+++ b/tests/test_validate_tasks.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import pytest
 
 from harness import validate
+from harness.agent.loop import _executor_runner
 from harness.tasks import Task
+from harness.verifier import host_runner
 
 
 def _full_task(root: Path, task_id: str = "demo", gold: str = "") -> Path:
@@ -235,9 +237,6 @@ def test_validate_docker_ignores_missing_host_toolchain(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Docker mode runs verifiers in the sandbox image, not on the host PATH."""
-    from harness.agent.loop import _executor_runner
-    from harness.verifier import host_runner
-
     task = _full_task(tmp_path, gold=_SOLVING_GOLD)
 
     class FakeExecutor:
@@ -252,7 +251,9 @@ def test_validate_docker_ignores_missing_host_toolchain(
         def close(self) -> None:
             pass
 
-    def fake_docker_runner(task: Task, workspace: Path, image: str | None) -> tuple[object, FakeExecutor]:
+    def fake_docker_runner(
+        task: Task, workspace: Path, image: str | None
+    ) -> tuple[object, FakeExecutor]:
         ex = FakeExecutor(workspace)
         return _executor_runner(ex), ex
 


### PR DESCRIPTION
## Summary
Fixes the current Python CI failures on `main` by addressing Ruff lint/format issues and the mypy errors in the cost-estimation CLI path. This keeps the cost-estimation behavior unchanged while making the latest validation/sandbox changes pass the repo's stated checks.

## Type of change
- [x] Bug fix
- [ ] New feature / harness capability
- [ ] New seed task (see TASK_CONTRIBUTION checklist below)
- [ ] Documentation only
- [ ] Refactor / DX

## What changed
- Added targeted `noqa` annotations for existing linear cost-prior fallback/validation functions that exceed Ruff complexity thresholds.
- Replaced ambiguous Unicode multiplication symbols in `scripts/export_cost_priors.py` output with ASCII `x`.
- Moved validation-test imports to module scope to satisfy Ruff.
- Added a small `_selected_task_ids()` helper so mypy can prove `estimate_plan()` receives `list[str]` without ignored narrowing.
- Applied Ruff formatting to files that CI would otherwise reject after lint passes.

## Checklist
- [x] `make ci` (lint + type + fast tests) passes locally
- [x] New code has tests (or existing coverage not regressed)
- [x] Docs updated if user-facing
- [x] No secrets or large binaries committed
- [ ] For tasks: gold-patch run 3x on ARM64 + x86, validation script output attached

## How I tested this
- `uvx ruff check .` reproduced the seven Ruff failures from the latest failed CI run.
- `make ci PYTHON=python3.12`
  - Ruff check: passed
  - Ruff format check: passed
  - mypy: passed
  - pytest fast suite: `399 passed, 2 deselected`, coverage `84.76%`
- `PATH="$(pwd)/.venv/bin:$PATH" .venv/bin/python scripts/validate_tasks.py tasks/v1`
  - `52 passed, 1 skipped, 0 failed`

## Related issues
Closes #

First contribution to this project — let me know if I missed any local convention around using `noqa` versus refactoring complexity-only lint failures.
