### PR TITLE
Anthropic provider: refusal guard and output headroom for Fable 5

### DIFF
--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -295,7 +295,10 @@ class AnthropicProvider(LLMProvider):
         system_field, converted = _with_prompt_caching(system, converted)
         payload: dict[str, Any] = {
             "model": self.model,
-            "max_tokens": 4096,
+            # Thinking counts toward max_tokens on always-on-thinking models
+            # (Fable 5) and adaptive-by-default models (Sonnet 5); 4096 could
+            # truncate a thinking-heavy step to an empty response.
+            "max_tokens": 16000,
             "messages": converted,
         }
         if effort is not None:
@@ -314,6 +317,13 @@ class AnthropicProvider(LLMProvider):
             payload,
             timeout=timeout,
         )
+        if body.get("stop_reason") == "refusal":
+            details = body.get("stop_details") or {}
+            raise ProviderError(
+                "model refused the request"
+                f" (category={details.get('category')!r}):"
+                f" {details.get('explanation') or 'no explanation provided'}"
+            )
         content_text: list[str] = []
         tool_calls: list[ToolInvocation] = []
         for block in body.get("content", []):

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -56,3 +56,6 @@ def test_anthropic_frontier_models_priced() -> None:
     # Opus 4.8: input 5.00/1M, output 25.00/1M -> 30.00. Both are needed for the
     # effort-sweep cost/Pareto axis; an unpriced model silently yields cost=None.
     assert pricing.cost_usd("anthropic:claude-opus-4-8", 1_000_000, 1_000_000) == 30.0
+    # Fable 5: input 10.00/1M, output 50.00/1M -> 60.00.
+    assert pricing.is_priced("anthropic:claude-fable-5")
+    assert pricing.cost_usd("anthropic:claude-fable-5", 1_000_000, 1_000_000) == 60.0


### PR DESCRIPTION
## What changed

Two small provider changes plus a pricing test, all shaken out by running the first three-way benchmark (Claude Fable 5 low effort vs Claude Sonnet 5 high effort vs GLM-5.2) on the v2 suite:

1. **Refusal guard.** `stop_reason: "refusal"` now raises a `ProviderError` carrying the `stop_details` category and explanation, instead of silently returning an empty response that the agent loop would burn steps on. This fired in production during the benchmark: Fable 5's cyber classifier refused `oss-aiohttp-upgrade-deferred` (a benign HTTP-parser bug fix flagged as cyber content) before the first token. With the guard, the run recorded a clean categorized error; without it, we'd have had an unexplained zero.
2. **Output headroom.** `max_tokens` raised from 4096 to 16000 on the Anthropic path. Thinking tokens count against the output cap on Fable 5 (thinking always on) and Sonnet 5 (adaptive by default), so 4096 could truncate a thinking-heavy step into an empty response mid-run.
3. **Pricing test** now asserts Fable 5 at $10/$50 per MTok (the table entry already existed).

## Reviewer notes

- The provider already omitted the `thinking` parameter and sampling params, which is exactly what Fable 5 requires, so no request-shape changes were needed.
- No fallback models are configured deliberately: for a benchmark, a refusal must score as a failure, not get silently rescued by a different model.
- Benchmark context: all three models scored 8/10 on the verified v2 suite, failing the same two tasks; costs were $2.27 (Fable-low) / $8.41 (Sonnet-high) / $15.81 (GLM-5.2). Raw runs in `../vb-3way`.
- Tests: pricing + provider suites green (39 passed); ruff lint and format clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)