### PR TITLE
Discount OpenAI cached prompt tokens in cost accounting

### DIFF
--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -610,11 +610,29 @@ def _parse_responses_body(body: dict[str, Any]) -> LLMResponse:
         content="\n".join(part for part in content_parts if part) or None,
         tool_calls=tool_calls,
         usage=TokenUsage(
-            prompt_tokens=usage.get("input_tokens", usage.get("prompt_tokens", 0)),
+            prompt_tokens=_openai_effective_prompt_tokens(
+                usage.get("input_tokens", usage.get("prompt_tokens", 0)),
+                (usage.get("input_tokens_details") or {}).get("cached_tokens", 0),
+            ),
             completion_tokens=usage.get("output_tokens", usage.get("completion_tokens", 0)),
         ),
         raw=body,
     )
+
+
+def _openai_effective_prompt_tokens(input_tokens: int, cached_tokens: int) -> int:
+    """Fold OpenAI's automatic prompt-cache discount into an effective prompt count.
+
+    Unlike Anthropic (where ``input_tokens`` is the uncached remainder), OpenAI reports
+    ``input_tokens`` as the FULL prompt and carries the cached portion in
+    ``input_tokens_details.cached_tokens``. Cached input on the GPT-5 series bills at
+    ~0.1x the input rate, so the re-sent transcript in a long agent loop is far cheaper
+    than the raw token count implies. Fold cache reads at 0.1x so ``cost_usd`` reflects
+    what OpenAI actually bills.
+    """
+    cached = min(max(cached_tokens, 0), input_tokens)
+    uncached = input_tokens - cached
+    return round(uncached + cached * 0.1)
 
 
 def _parse_chat_completions_response(body: dict[str, Any]) -> LLMResponse:
@@ -633,7 +651,10 @@ def _parse_chat_completions_response(body: dict[str, Any]) -> LLMResponse:
         content=msg.get("content"),
         tool_calls=tool_calls,
         usage=TokenUsage(
-            prompt_tokens=usage.get("prompt_tokens", 0),
+            prompt_tokens=_openai_effective_prompt_tokens(
+                usage.get("prompt_tokens", 0),
+                (usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0),
+            ),
             completion_tokens=usage.get("completion_tokens", 0),
         ),
         raw=body,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -233,6 +233,34 @@ def test_openai_effort_uses_responses_payload(monkeypatch: pytest.MonkeyPatch) -
     assert resp.usage.total == 14
 
 
+def test_openai_responses_discounts_cached_prompt_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OpenAI reports input_tokens as the FULL prompt, with the cached portion in
+    # input_tokens_details.cached_tokens (billed ~0.1x on the GPT-5 series). The
+    # effective prompt count must fold cache reads at 0.1x, not bill them full price.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    def fake_post(url, headers, payload, timeout=120):  # type: ignore[no-untyped-def]
+        return {
+            "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+            "usage": {
+                "input_tokens": 10000,
+                "input_tokens_details": {"cached_tokens": 9000},
+                "output_tokens": 100,
+            },
+        }
+
+    monkeypatch.setattr(P, "_http_post_json", fake_post)
+    resp = OpenAIProvider("gpt-5.5").complete(
+        [{"role": "user", "content": "hi"}], [], effort="high"
+    )
+    # 1000 uncached + 9000 cached * 0.1 = 1000 + 900 = 1900 effective prompt tokens
+    # (a full-price count would have been 10000).
+    assert resp.usage.prompt_tokens == 1900
+    assert resp.usage.completion_tokens == 100
+
+
 def test_openai_complete_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     with pytest.raises(P.ProviderError, match="OPENAI_API_KEY"):


### PR DESCRIPTION
## What changed

The OpenAI/Responses provider path billed every prompt token at the full input rate, ignoring OpenAI's automatic prompt-cache discount. OpenAI reports `input_tokens` as the **full** prompt (unlike Anthropic, where it is the uncached remainder) and puts the cached portion in `input_tokens_details.cached_tokens`, billed at ~0.1x on the GPT-5 series. In a long agent loop, the entire re-sent transcript was billed uncached on every turn.

This inflated GPT-5.5's reported cost by roughly **6x** in a recent 15-eval run (reported ~$119 vs. an actual ~$20 on the provider dashboard), because GPT-5.5 averaged 2-3x more agent steps than the other models so its whole history was re-billed uncached each turn.

The new `_openai_effective_prompt_tokens()` folds cache reads at 0.1x, mirroring the existing Anthropic caching path, and is applied to both `_parse_responses_body` (effort/Responses API) and `_parse_chat_completions_response`. A unit test asserts a 9,000-of-10,000-cached prompt counts as 1,900 effective tokens.

## Reviewer notes

- Discovered when a run's reported GPT-5.5 total did not match the actual API spend. The Anthropic path already handled caching; only the OpenAI path was missing it.
- No change to grading, task execution, or the Anthropic/zai paths, purely the OpenAI cost-accounting field.
- `tests/test_providers.py` + `tests/test_pricing.py` green; ruff lint and format clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)