### PR TITLE
Calibrate the veryhard tier: fair-hard instead of under-specified

### DIFF
--- a/tasks/v2/oss-networkx-leiden-communities/issue.md
+++ b/tasks/v2/oss-networkx-leiden-communities/issue.md
@@ -8,22 +8,39 @@ backend.
 
 The Leiden algorithm improves on Louvain by guaranteeing well-connected
 communities. A correct implementation performs, per level: a fast local-moving
-phase that greedily moves nodes between communities to improve a quality
+phase that greedily moves nodes between communities to improve the quality
 function, a refinement phase that may split communities into well-connected
 sub-communities, and an aggregation phase that collapses each refined community
 into a super-node before repeating on the aggregated graph, until no further
 improvement is possible.
+
+The quality function optimized is the Constant Potts Model (CPM), the standard
+objective for Leiden:
+
+    Q = sum over communities c of [ e_c - resolution * n_c * (n_c - 1) / 2 ]
+
+where `e_c` is the total weight of edges inside community `c` and `n_c` its
+number of nodes (for weighted graphs, `e_c` uses the `weight` attribute). Note
+this is CPM, not modularity: at `resolution=1` on sparse graphs it legitimately
+produces many small communities.
 
 Requirements:
 
 - `leiden_communities(G, weight="weight", resolution=1, ..., seed=None)` returns
   the final list of communities (sets of nodes).
 - `leiden_partitions(G, ...)` yields the successive partitions produced at each
-  level of the algorithm.
-- The `resolution` parameter controls community granularity (higher resolution
-  yields more, smaller communities).
-- Results must be deterministic given a fixed `seed`, and must exactly match the
-  reference algorithm's output for a given graph, seed, and resolution.
-- Every node must appear in exactly one community.
+  level of the algorithm, with the final level equal to what
+  `leiden_communities` returns.
+- The `resolution` parameter is the CPM resolution: higher resolution yields
+  more, smaller communities.
+- Results must be deterministic given a fixed `seed` (the same seed reproduces
+  the same partition; different correct implementations may produce different
+  partitions of comparable CPM quality).
+- Every returned community must induce a connected subgraph (the Leiden
+  guarantee), and every node must appear in exactly one community.
+- Partitions must be genuinely good under CPM at the requested resolution: for
+  example, on `nx.karate_club_graph()` at `resolution=0.5` the reference lands
+  around Q = 2 to 8.5 depending on seed (degenerate outputs like all-singletons
+  score 0, and modularity-style giant communities score far below 0).
 
 Existing community-detection functions must be unaffected.

--- a/tasks/v2/oss-networkx-leiden-communities/metadata.json
+++ b/tasks/v2/oss-networkx-leiden-communities/metadata.json
@@ -1,7 +1,9 @@
 {
   "id": "oss-networkx-leiden-communities",
   "category": "feature",
-  "languages": ["python"],
+  "languages": [
+    "python"
+  ],
   "difficulty": "hard",
   "task_complexity": "system",
   "created": "2026-07-03",
@@ -14,17 +16,40 @@
     "issue": "https://github.com/networkx/networkx/pull/8509",
     "commit": "4857d9a2580810605facc26f3dc7d23f8c04c1cd"
   },
-  "decontamination_notes": "Real feature from networkx/networkx PR #8509, merged 2026-05-12, after model training cutoffs. A 600-line net-new native implementation of the full Leiden community-detection algorithm (local move, refinement, aggregation, CPM quality), where only a backend-dispatch stub existed at base. Graded on exact reproduction of the reference partition for fixed graph/seed/resolution plus validity and no-regression checks; a merely-plausible implementation that produces a different partition fails. Repo sliced at base commit (193k LOC); BSD LICENSE preserved. networkx has no required runtime deps, so this runs in the base sandbox image with PYTHONPATH=.",
+  "decontamination_notes": "Real feature from networkx/networkx PR #8509, merged 2026-05-12, after model training cutoffs. A 600-line net-new native implementation of the full Leiden community-detection algorithm (local move, refinement, aggregation, CPM quality), where only a backend-dispatch stub existed at base. Graded on exact reproduction of the reference partition for fixed graph/seed/resolution plus validity and no-regression checks; a merely-plausible implementation that produces a different partition fails. Repo sliced at base commit (193k LOC); BSD LICENSE preserved. networkx has no required runtime deps, so this runs in the base sandbox image with PYTHONPATH=. CALIBRATED 2026-07-04: exact-seed-partition grading replaced by semantic grading (CPM quality thresholds on karate club + les miserables, community connectivity guarantee, resolution semantics, seed determinism) after benchmark runs showed the exact-match test required reproducing the reference's incidental RNG consumption order, which correct implementations cannot derive. Thresholds set below the reference's across-seed floor and far above degenerate/naive baselines.",
   "grader": "tests",
   "tests": {
     "fail_to_pass": [
-      {"name": "reference_partition", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_reproduces_reference_partition -q"},
-      {"name": "resolution", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_honors_resolution -q"},
-      {"name": "partitions_generator", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_partitions_generator -q"},
-      {"name": "valid_partition", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_is_a_valid_partition -q"}
+      {
+        "name": "partition_quality",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_partition_quality -q"
+      },
+      {
+        "name": "communities_connected",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_communities_are_connected -q"
+      },
+      {
+        "name": "resolution",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_honors_resolution -q"
+      },
+      {
+        "name": "deterministic_seed",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_deterministic_for_seed -q"
+      },
+      {
+        "name": "partitions_generator",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_partitions_generator -q"
+      },
+      {
+        "name": "valid_partition",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_leiden_is_a_valid_partition -q"
+      }
     ],
     "pass_to_pass": [
-      {"name": "modularity_unaffected", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_modularity_communities_unaffected -q"}
+      {
+        "name": "modularity_unaffected",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_modularity_communities_unaffected -q"
+      }
     ]
   },
   "test_timeout_s": 300

--- a/tasks/v2/oss-networkx-leiden-communities/tests/oss_tests.py
+++ b/tasks/v2/oss-networkx-leiden-communities/tests/oss_tests.py
@@ -1,46 +1,84 @@
 """Hidden test for oss-networkx-leiden-communities.
 
 A native NetworkX implementation of the Leiden community-detection algorithm
-must be added (`leiden_communities` and `leiden_partitions`), reproducing the
-reference partition exactly for a fixed graph and seed, and honoring the
-resolution parameter. Expected behavior captured from the upstream feature
-(networkx/networkx PR #8509).
+must be added (`leiden_communities` and `leiden_partitions`). Grading is
+semantic rather than exact-partition-matching (a seeded run's exact partition
+depends on incidental RNG consumption order, which correct implementations
+legitimately differ on). What is graded, on two graphs:
 
-Run with PYTHONPATH=. so the workspace networkx is under test.
+- partition QUALITY under the constant Potts model at resolution 0.5, with
+  thresholds far above degenerate outputs (singletons score 0, classic
+  label-propagation/greedy-modularity score deeply negative) yet below the
+  across-seed floor of the reference implementation;
+- Leiden's defining GUARANTEE: every returned community induces a connected
+  subgraph (the property that separates Leiden from Louvain);
+- resolution semantics: lower resolution coarsens the partition;
+- seed determinism: the same seed reproduces the same partition;
+- the `leiden_partitions` generator contract: its final level equals the
+  top-level `leiden_communities` result.
+
+Expected behavior captured from the upstream feature (networkx/networkx PR
+#8509). Run with PYTHONPATH=. so the workspace networkx is under test.
 """
 from __future__ import annotations
 
 import networkx as nx
 
-KARATE_SEED7 = [
-    [0, 1, 2, 3, 7, 13],
-    [4, 10],
-    [5, 6, 16],
-    [8, 23, 25, 30, 31, 32, 33],
-    [9], [11], [12], [14], [15], [17], [18], [19], [20], [21], [22],
-    [24, 27], [26, 29], [28],
-]
-KARATE_RES05 = [
-    [0, 1, 2, 3, 7, 13],
-    [4, 5, 6, 10, 16],
-    [8, 15, 23, 26, 29, 30, 32, 33],
-    [9], [11], [12], [14], [17], [18], [19], [20], [21], [22],
-    [24, 25, 27, 28, 31],
-]
-
 
 def _canon(communities):
-    return sorted(sorted(int(n) for n in c) for c in communities)
+    return sorted(sorted(n for n in c) for c in communities)
 
 
-def test_leiden_reproduces_reference_partition():
+def _cpm(G, communities, resolution):
+    """Constant Potts Model score: sum_c (e_c - resolution * n_c*(n_c-1)/2)."""
+    score = 0.0
+    for c in communities:
+        cs = set(c)
+        e_c = G.subgraph(cs).number_of_edges()
+        n = len(cs)
+        score += e_c - resolution * n * (n - 1) / 2
+    return score
+
+
+def test_leiden_partition_quality():
+    # Karate club: reference implementation scores 2.0-8.5 across seeds at
+    # resolution 0.5; singletons score 0; label propagation scores -54.
     G = nx.karate_club_graph()
-    assert _canon(nx.community.leiden_communities(G, seed=7)) == KARATE_SEED7
+    comms = nx.community.leiden_communities(G, resolution=0.5, seed=7)
+    assert _cpm(G, comms, 0.5) >= 1.5
+
+    # Les Miserables: reference scores 55-66 at resolution 0.5; label
+    # propagation scores -91.
+    H = nx.les_miserables_graph()
+    comms_h = nx.community.leiden_communities(H, resolution=0.5, seed=7)
+    assert _cpm(H, comms_h, 0.5) >= 30.0
+
+
+def test_leiden_communities_are_connected():
+    # Leiden's defining guarantee over Louvain: communities are connected.
+    for G in (nx.karate_club_graph(), nx.les_miserables_graph()):
+        for res in (1.0, 0.5):
+            comms = nx.community.leiden_communities(G, resolution=res, seed=7)
+            for c in comms:
+                if len(c) > 1:
+                    assert nx.is_connected(G.subgraph(c)), (
+                        f"community {sorted(c)} is disconnected at resolution {res}"
+                    )
 
 
 def test_leiden_honors_resolution():
+    # Lower resolution -> fewer, larger communities.
     G = nx.karate_club_graph()
-    assert _canon(nx.community.leiden_communities(G, resolution=0.5, seed=7)) == KARATE_RES05
+    n_high = len(nx.community.leiden_communities(G, resolution=1.0, seed=7))
+    n_low = len(nx.community.leiden_communities(G, resolution=0.5, seed=7))
+    assert n_low < n_high
+
+
+def test_leiden_deterministic_for_seed():
+    G = nx.karate_club_graph()
+    a = nx.community.leiden_communities(G, seed=7)
+    b = nx.community.leiden_communities(G, seed=7)
+    assert _canon(a) == _canon(b)
 
 
 def test_leiden_partitions_generator():

--- a/tasks/v2/oss-pennylane-labs-arithmetic/issue.md
+++ b/tasks/v2/oss-pennylane-labs-arithmetic/issue.md
@@ -32,6 +32,24 @@ Semantics:
   the estimator accounts T gates for phase rotations, Toffolis, CNOT ladders,
   and QFT Hadamards.
 
+Acceptance examples with exact counts, pinning the cost model:
+
+```pycon
+>>> import pennylane.labs.estimator_beta as qre
+>>> r = qre.estimate(qre.LabsPhaseAdder(num_x_wires=4))
+>>> int(r.total_wires), int(r.total_gates)
+(4, 176)                      # all T gates (176), no auxiliary wires
+
+>>> r = qre.estimate(qre.LabsAdder(num_x_wires=5, mod=19))
+>>> int(r.total_wires), int(r.algo_wires), int(r.zeroed_wires), int(r.total_gates)
+(7, 5, 2, 14014)              # T: 13728, CNOT: 248, Hadamard: 36, X: 2
+
+>>> r = qre.estimate(qre.LabsModExp(num_x_wires=4, num_output_wires=5, mod=21))
+>>> int(r.total_wires), int(r.algo_wires), int(r.zeroed_wires), int(r.total_gates)
+(17, 9, 8, 604300)            # T: 591360, CNOT: 10840, Hadamard: 1440,
+                              # Toffoli: 580, X: 80
+```
+
 Export all six from `pennylane.labs.estimator_beta` and from
 `pennylane.labs.estimator_beta.templates`. Existing operators (including
 `LabsQROM` and `SelectCopyQROM`) must be unchanged.

--- a/tasks/v2/oss-pennylane-labs-arithmetic/metadata.json
+++ b/tasks/v2/oss-pennylane-labs-arithmetic/metadata.json
@@ -1,7 +1,9 @@
 {
   "id": "oss-pennylane-labs-arithmetic",
   "category": "feature",
-  "languages": ["python"],
+  "languages": [
+    "python"
+  ],
   "difficulty": "hard",
   "task_complexity": "system",
   "created": "2026-07-04",
@@ -15,19 +17,40 @@
     "issue": "https://github.com/PennyLaneAI/pennylane/pull/9390",
     "commit": "e4bf9c8a3adc5640a8504ba8207a07a333e456ff"
   },
-  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9390, merged 2026-06-25, after model training cutoffs. Adds a 1000-line net-new arithmetic.py with six Fourier-space arithmetic resource operators (LabsPhaseAdder, LabsAdder, LabsOutAdder, ClassicalOutMultiplier, LabsMultiplier, LabsModExp) to labs/estimator_beta. Graded on EXACT wire and gate counts across eight parameter regimes (e.g. LabsModExp(6, 8, mod=201) = 3,155,328 T gates): the counts encode which building blocks each operator decomposes into, the modular-reduction circuitry (extra work wires, controlled corrections), phase-rotation T-counts, and auxiliary wire bookkeeping. Textbook-faithful from-scratch implementations that differ in any internal choice yield different counts. Same recipe as oss-pennylane-selectcopy-qrom, which Fable-low failed (all-recon DNF). Repo sliced at the PR base commit (280k LOC, arithmetic.py absent; LabsQROM and SelectCopyQROM exist at base and are guarded by a pass_to_pass test). Apache-2.0 LICENSE preserved. Reuses the pennylane-9459 image; pure counting, no device execution.",
+  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9390, merged 2026-06-25, after model training cutoffs. Adds a 1000-line net-new arithmetic.py with six Fourier-space arithmetic resource operators (LabsPhaseAdder, LabsAdder, LabsOutAdder, ClassicalOutMultiplier, LabsMultiplier, LabsModExp) to labs/estimator_beta. Graded on EXACT wire and gate counts across eight parameter regimes (e.g. LabsModExp(6, 8, mod=201) = 3,155,328 T gates): the counts encode which building blocks each operator decomposes into, the modular-reduction circuitry (extra work wires, controlled corrections), phase-rotation T-counts, and auxiliary wire bookkeeping. Textbook-faithful from-scratch implementations that differ in any internal choice yield different counts. Same recipe as oss-pennylane-selectcopy-qrom, which Fable-low failed (all-recon DNF). Repo sliced at the PR base commit (280k LOC, arithmetic.py absent; LabsQROM and SelectCopyQROM exist at base and are guarded by a pass_to_pass test). Apache-2.0 LICENSE preserved. Reuses the pennylane-9459 image; pure counting, no device execution. CALIBRATED 2026-07-04: benchmark runs showed the graded conventions were under-specified relative to exact-output grading (all configs 0/5 on the veryhard tier), so the issue now includes an acceptance example with exact reference values for a small instance DISTINCT from the hidden graded cases. The conventions are thereby fully verifiable from the issue; the hidden tests still require implementing the full algorithm correctly at other parameter points.",
   "grader": "tests",
   "tests": {
     "fail_to_pass": [
-      {"name": "phase_adder", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_phase_adder_counts -q"},
-      {"name": "adder", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_adder_counts -q"},
-      {"name": "outadder_multiplier", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_out_adder_and_classical_multiplier_counts -q"},
-      {"name": "multiplier", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_multiplier_counts -q"},
-      {"name": "modexp", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_modexp_counts -q"},
-      {"name": "validation_exports", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_validation_and_exports -q"}
+      {
+        "name": "phase_adder",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_phase_adder_counts -q"
+      },
+      {
+        "name": "adder",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_adder_counts -q"
+      },
+      {
+        "name": "outadder_multiplier",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_out_adder_and_classical_multiplier_counts -q"
+      },
+      {
+        "name": "multiplier",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_multiplier_counts -q"
+      },
+      {
+        "name": "modexp",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_modexp_counts -q"
+      },
+      {
+        "name": "validation_exports",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_validation_and_exports -q"
+      }
     ],
     "pass_to_pass": [
-      {"name": "estimator_unaffected", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_estimator_unaffected -q"}
+      {
+        "name": "estimator_unaffected",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_estimator_unaffected -q"
+      }
     ]
   },
   "test_timeout_s": 600

--- a/tasks/v2/oss-pennylane-selectcopy-qrom/issue.md
+++ b/tasks/v2/oss-pennylane-selectcopy-qrom/issue.md
@@ -51,3 +51,27 @@ Example from the resource-estimation workflow:
    'X': 7.036E+6,
    'Hadamard': 1.055E+7
 ```
+
+Acceptance example with exact integer counts, pinning the cost model. The
+parameter optimization brute-forces the Theorem 1 Toffoli cost
+
+```
+cost(N, b, mu, lam) = (ceil(b/mu) + 1) * (ceil(N/lam) + lam - 5)
+                      + (lam - 1) * (mu * (floor(b/mu) + 1) + b % mu)
+```
+
+over bits-per-iteration `mu in 1..b` and batch sizes `lam` restricted to powers
+of two (`lam = 2, 4, 8, ...` up to `2**floor(log2(N-1))`), subject to
+`mu * (lam - 1) <= available_dirty_aux`, taking the first minimum in that
+iteration order. For `num_bitstrings=2048, size_bitstring=16,
+available_dirty_aux=48` the estimate must come out exactly:
+
+```
+total wires: 83  (algorithmic 27, allocated zero-state 56)
+total gates: 41006
+  X:                2048
+  CNOT:             34782
+  Toffoli (left-elbow logical ANDs): 1020
+  Toffoli (plain):  96
+  Hadamard:         3060
+```

--- a/tasks/v2/oss-pennylane-selectcopy-qrom/metadata.json
+++ b/tasks/v2/oss-pennylane-selectcopy-qrom/metadata.json
@@ -1,7 +1,9 @@
 {
   "id": "oss-pennylane-selectcopy-qrom",
   "category": "feature",
-  "languages": ["python"],
+  "languages": [
+    "python"
+  ],
   "difficulty": "hard",
   "task_complexity": "system",
   "created": "2026-07-04",
@@ -15,17 +17,32 @@
     "issue": "https://github.com/PennyLaneAI/pennylane/pull/9500",
     "commit": "1d6349aaa973a898e9d500031954a0113a8d8c3c"
   },
-  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9500, merged 2026-05-20, after model training cutoffs. Adds a 758-line net-new SelectCopyQROM resource operator (Select-Copy QROM of Low et al. 2024, arXiv:1812.00954) to labs/estimator_beta. Graded on EXACT wire and gate counts (e.g. 457,037,936 CNOTs for one case) from qre.estimate over five parameter regimes: the counts encode the brute-force Theorem-1 parameter optimization (its eligibility sets restrict batch sizes to powers of two, its cost expression carries idiosyncratic constants, tie-breaking follows iteration order), the left-elbow vs plain Toffoli split, CNOT fan-out accounting, and auxiliary wire bookkeeping. A paper-faithful from-scratch implementation that differs in any internal choice yields different counts. The issue reproduces the upstream docstring example (one case); the other four graded cases are hidden. Repo sliced at the PR base commit (280k LOC, class absent; the sibling LabsQROM exists at base and is guarded by a pass_to_pass test). Apache-2.0 LICENSE preserved. Reuses the pennylane-9459 image (PL deps + jax); pure counting, no device execution.",
+  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9500, merged 2026-05-20, after model training cutoffs. Adds a 758-line net-new SelectCopyQROM resource operator (Select-Copy QROM of Low et al. 2024, arXiv:1812.00954) to labs/estimator_beta. Graded on EXACT wire and gate counts (e.g. 457,037,936 CNOTs for one case) from qre.estimate over five parameter regimes: the counts encode the brute-force Theorem-1 parameter optimization (its eligibility sets restrict batch sizes to powers of two, its cost expression carries idiosyncratic constants, tie-breaking follows iteration order), the left-elbow vs plain Toffoli split, CNOT fan-out accounting, and auxiliary wire bookkeeping. A paper-faithful from-scratch implementation that differs in any internal choice yields different counts. The issue reproduces the upstream docstring example (one case); the other four graded cases are hidden. Repo sliced at the PR base commit (280k LOC, class absent; the sibling LabsQROM exists at base and is guarded by a pass_to_pass test). Apache-2.0 LICENSE preserved. Reuses the pennylane-9459 image (PL deps + jax); pure counting, no device execution. CALIBRATED 2026-07-04: benchmark runs showed the graded conventions were under-specified relative to exact-output grading (all configs 0/5 on the veryhard tier), so the issue now includes an acceptance example with exact reference values for a small instance DISTINCT from the hidden graded cases. The conventions are thereby fully verifiable from the issue; the hidden tests still require implementing the full algorithm correctly at other parameter points.",
   "grader": "tests",
   "tests": {
     "fail_to_pass": [
-      {"name": "dirty_aux_optimized", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_dirty_aux_optimized_cases -q"},
-      {"name": "no_dirty_aux", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_no_dirty_aux_default -q"},
-      {"name": "explicit_params", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_explicit_batch_and_bits_per_iter -q"},
-      {"name": "exported", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_exported_from_estimator_beta -q"}
+      {
+        "name": "dirty_aux_optimized",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_dirty_aux_optimized_cases -q"
+      },
+      {
+        "name": "no_dirty_aux",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_no_dirty_aux_default -q"
+      },
+      {
+        "name": "explicit_params",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_explicit_batch_and_bits_per_iter -q"
+      },
+      {
+        "name": "exported",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_exported_from_estimator_beta -q"
+      }
     ],
     "pass_to_pass": [
-      {"name": "labs_qrom_unaffected", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_labs_qrom_unaffected -q"}
+      {
+        "name": "labs_qrom_unaffected",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_existing_labs_qrom_unaffected -q"
+      }
     ]
   },
   "test_timeout_s": 600

--- a/tasks/v2/oss-pennylane-trotter-fragmented/issue.md
+++ b/tasks/v2/oss-pennylane-trotter-fragmented/issue.md
@@ -37,15 +37,66 @@ implementation exactly; many mathematically equivalent circuits exist):
   one-body turn-around, across adjacent Trotter steps, and for the final
   restoring rotation after the last step. A rotation that merges to the
   identity is not emitted at all.
-- Two-body diagonals decompose into `IsingZZ` pairs plus the one-body
-  correction absorbed the way the reference does; one-body diagonals decompose
-  into per-wire `RZ` rotations.
+- Two-body diagonals decompose into `IsingZZ` pairs (one per spin-orbital wire
+  pair, with same-orbital pairs driven by the diagonal core entries and
+  cross-orbital pairs by the off-diagonal entries, all four spin combinations);
+  one-body diagonals decompose into per-wire `RZ` rotations. The linear
+  (one-body) corrections arising from the two-body diagonals are folded into
+  the trailing global phase, not emitted as extra rotations.
 - The accumulated scalar terms (`nuc_constant` plus the diagonal corrections)
   appear once at the end as `GlobalPhase(phi)` with `phi` reduced modulo
   `4*pi`.
 - With `control_wires` given (a single wire), the evolution uses the
   double-phase trick: diagonal rotations are sandwiched by `CNOT`s from the
   control, and the global phase becomes `RZ(-phi)` on the control wire.
+
+Acceptance example pinning the conventions. For a single-fragment CDF input on
+4 wires with one second-order Trotter step over `evolution_time=1.0`:
+
+```python
+def rot(t):
+    c, s = np.cos(t), np.sin(t)
+    return np.array([[c, -s], [s, c]])
+
+hamiltonian = {
+    "nuc_constant": 0.3,
+    "core_tensors": np.stack([np.diag([0.3, -0.1]),
+                              np.array([[0.25, 0.15], [0.15, -0.2]])]),
+    "leaf_tensors": np.stack([rot(0.4), rot(0.9)]),
+}
+trotter_fragmented(1.0, 1, hamiltonian, wires=[0, 1, 2, 3])
+```
+
+the queued circuit must be exactly (angles in radians; BasisRotation shown by
+its unitary's first row):
+
+```
+BasisRotation(U~[[0.6216, -0.7833], ...], wires=[0, 2])   # rot(0.9): two-body leaf
+BasisRotation(U~[[0.6216, -0.7833], ...], wires=[1, 3])
+IsingZZ(-0.03125, wires=[0, 1])
+IsingZZ(-0.01875, wires=[0, 2])
+IsingZZ(-0.01875, wires=[0, 3])
+IsingZZ(-0.01875, wires=[1, 2])
+IsingZZ(-0.01875, wires=[1, 3])
+IsingZZ(0.025,    wires=[2, 3])
+BasisRotation(U~[[0.8776, 0.4794], ...], wires=[0, 2])    # rot(0.9)^T @ rot(0.4): merged into one-body
+BasisRotation(U~[[0.8776, 0.4794], ...], wires=[1, 3])
+RZ(0.15,  wires=[0])
+RZ(0.15,  wires=[1])
+RZ(-0.05, wires=[2])
+RZ(-0.05, wires=[3])
+BasisRotation(U~[[0.8776, -0.4794], ...], wires=[0, 2])   # rot(0.4)^T @ rot(0.9): merged back
+BasisRotation(U~[[0.8776, -0.4794], ...], wires=[1, 3])
+IsingZZ(-0.03125, wires=[0, 1])
+IsingZZ(-0.01875, wires=[0, 2])
+IsingZZ(-0.01875, wires=[0, 3])
+IsingZZ(-0.01875, wires=[1, 2])
+IsingZZ(-0.01875, wires=[1, 3])
+IsingZZ(0.025,    wires=[2, 3])
+BasisRotation(U~[[0.6216, 0.7833], ...], wires=[0, 2])    # rot(0.9)^T: final restore
+BasisRotation(U~[[0.6216, 0.7833], ...], wires=[1, 3])
+GlobalPhase(0.3375, wires=[])
+```
 
 Export `trotter_fragmented` from `pennylane.labs.templates`. Existing labs
 templates and core PennyLane behavior must be unchanged.

--- a/tasks/v2/oss-pennylane-trotter-fragmented/metadata.json
+++ b/tasks/v2/oss-pennylane-trotter-fragmented/metadata.json
@@ -1,7 +1,9 @@
 {
   "id": "oss-pennylane-trotter-fragmented",
   "category": "feature",
-  "languages": ["python"],
+  "languages": [
+    "python"
+  ],
   "difficulty": "hard",
   "task_complexity": "system",
   "created": "2026-07-03",
@@ -15,18 +17,36 @@
     "issue": "https://github.com/PennyLaneAI/pennylane/pull/9459",
     "commit": "7bf1af3c952c11bd716f7859887eb17fe9a5f4de"
   },
-  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9459, merged 2026-06-02, after model training cutoffs. Adds a 402-line net-new second-order Trotter template for fragmented (CDF/CGF) Hamiltonians to pennylane.labs. Graded on the EXACT emitted gate stream: the reference merges adjacent fragment basis rotations into one BasisRotation per boundary (including across Trotter steps and the one-body turn-around), skips rotations that merge to identity, uses a specific RZ/IsingZZ decomposition of the diagonals, and emits the accumulated energy shift as a trailing GlobalPhase reduced mod 4*pi (RZ(-phi) on the control wire in the controlled variant). Many mathematically equivalent circuits produce the same unitary but a different op stream, and the merging/skip/phase conventions have no in-repo precedent to copy (labs research code), so a plausible correct-from-first-principles implementation fails the exact-match assertions. Repo sliced at the PR base commit (280k LOC, template absent); Apache-2.0 LICENSE preserved. Runs in the pennylane-9459 image (PennyLane runtime deps + jax, pennylane itself imported from the workspace via PYTHONPATH; tests only capture the queued ops, no device execution).",
+  "decontamination_notes": "Real feature from PennyLaneAI/pennylane PR #9459, merged 2026-06-02, after model training cutoffs. Adds a 402-line net-new second-order Trotter template for fragmented (CDF/CGF) Hamiltonians to pennylane.labs. Graded on the EXACT emitted gate stream: the reference merges adjacent fragment basis rotations into one BasisRotation per boundary (including across Trotter steps and the one-body turn-around), skips rotations that merge to identity, uses a specific RZ/IsingZZ decomposition of the diagonals, and emits the accumulated energy shift as a trailing GlobalPhase reduced mod 4*pi (RZ(-phi) on the control wire in the controlled variant). Many mathematically equivalent circuits produce the same unitary but a different op stream, and the merging/skip/phase conventions have no in-repo precedent to copy (labs research code), so a plausible correct-from-first-principles implementation fails the exact-match assertions. Repo sliced at the PR base commit (280k LOC, template absent); Apache-2.0 LICENSE preserved. Runs in the pennylane-9459 image (PennyLane runtime deps + jax, pennylane itself imported from the workspace via PYTHONPATH; tests only capture the queued ops, no device execution). CALIBRATED 2026-07-04: benchmark runs showed the graded conventions were under-specified relative to exact-output grading (all configs 0/5 on the veryhard tier), so the issue now includes an acceptance example with exact reference values for a small instance DISTINCT from the hidden graded cases. The conventions are thereby fully verifiable from the issue; the hidden tests still require implementing the full algorithm correctly at other parameter points.",
   "grader": "tests",
   "tests": {
     "fail_to_pass": [
-      {"name": "cdf_exact_stream", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_exact_gate_stream -q"},
-      {"name": "cdf_merged_rotations", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_merged_basis_rotation_matrices -q"},
-      {"name": "cdf_controlled", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_controlled_double_phase -q"},
-      {"name": "cgf_exact_stream", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cgf_exact_gate_stream -q"},
-      {"name": "shape_validation", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_shape_autodetection_rejects_bad_input -q"}
+      {
+        "name": "cdf_exact_stream",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_exact_gate_stream -q"
+      },
+      {
+        "name": "cdf_merged_rotations",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_merged_basis_rotation_matrices -q"
+      },
+      {
+        "name": "cdf_controlled",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cdf_controlled_double_phase -q"
+      },
+      {
+        "name": "cgf_exact_stream",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_cgf_exact_gate_stream -q"
+      },
+      {
+        "name": "shape_validation",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_shape_autodetection_rejects_bad_input -q"
+      }
     ],
     "pass_to_pass": [
-      {"name": "core_unaffected", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_core_pennylane_unaffected -q"}
+      {
+        "name": "core_unaffected",
+        "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py::test_core_pennylane_unaffected -q"
+      }
     ]
   },
   "test_timeout_s": 600


### PR DESCRIPTION
## Why

The first full benchmark run (Fable/Opus × low/high, 2026-07-04) showed the veryhard tier was a wall: **0/5 binary pass@1 in every config**. Per-test analysis found part of the gap was under-specification — graded conventions that a correct implementation cannot derive from the issue — rather than pure difficulty.

## What

**leiden — semantic grading replaces exact-partition matching.** The old test required reproducing the reference's incidental RNG consumption order. New tests: CPM quality thresholds on two graphs (below the reference's own across-seed floor, far above degenerate baselines — singletons score 0, label-propagation scores −54/−91), the Leiden connectivity guarantee, resolution semantics, and seed determinism. The issue now names the CPM objective with its formula (it previously said only "a quality function"). Revalidated: gold=1.0, pre-patch=0.0, deterministic.

**The 3 pennylane tasks — acceptance examples added, exact-output grading kept.** Each issue now includes exact reference values for a small instance *distinct* from the hidden graded cases (trotter: a complete 25-op stream; qrom: the Theorem-1 cost expression + exact counts; arithmetic: exact counts for three small operators). Conventions are verifiable; passing still requires a correct full implementation at other parameter points.

**canonicalize — untouched** (already the ideal shape: Opus 1/6 low → 5/6 high).

## Verification

Post-calibration Opus screens: low 0/5 (func avg 0.26→0.36), high 0/5 (func avg 0.42→0.49). The remaining failures are genuine capability gaps, not unknowable conventions — the sharpest example: with CPM explicitly specified in the issue including a "this is not modularity" warning, Opus-high still produced modularity-style giant communities scoring −68/−501 against a threshold of 1.5/30. Prior overriding instructions is exactly the failure mode the tier should catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)