### PR TITLE
Add per-run cost cap and zero-cost regrade command

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -89,10 +89,32 @@ vulcanbench report --suite v1 -o report.md
 >   cheap functional-only runs.
 > - `--max-cost` is a soft cap that stops launching new runs (suite runs only)
 >   and requires a priced model; cost/latency are recorded per run regardless.
+> - `--max-run-cost` is a **per-run** hard ceiling: an individual agent run stops
+>   once its own spend crosses the value (overshoot bounded by one model call),
+>   the summary records `cost_capped: true`, and the partial result is still
+>   graded honestly. Ideal for the hard tier, where a failing run can otherwise
+>   ruminate to the step cap — `--max-run-cost 2.50` turns "$8 DNF" into "$2.50
+>   DNF" and loses no signal (works on single `--task` and suite/sweep runs).
 > - Default `--sandbox docker` runs the agent's shell commands in an isolated
 >   container. Use `--sandbox local` only for trusted dev loops (e.g.
 >   `mock:synthetic`). Override prices any time with
 >   `VULCANBENCH_PRICING=/path/to/prices.json`.
+
+**Re-grade for free after a task changes.** Grading is deterministic, so when you
+edit a task's hidden tests or thresholds you don't need to re-run the model —
+just re-grade the existing runs. `regrade` rebuilds each run's workspace from the
+task base plus the captured agent patch, overlays the *current* tests, and
+re-verifies in the sandbox at zero API cost:
+
+```bash
+# one run, or an entire directory of runs
+vulcanbench regrade runs/<run-id> --sandbox docker
+vulcanbench regrade runs/ --sandbox docker            # regrades every run under it
+```
+
+It prints old → new functional per run and writes `regrade.json` into each run
+dir. Use it to re-score historical runs against a calibrated task without paying
+for a single new model call.
 
 See the full example in the README and `docs/ARCHITECTURE.md`. To add your own
 task: `docs/TASK_CONTRIBUTION.md`.

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -136,6 +136,7 @@ def run_agent(
     timeout_s: float | None = None,
     effort: str | None = None,
     experiment_id: str | None = None,
+    max_run_cost: float | None = None,
 ) -> dict[str, Any]:
     """Run one evaluation: agent solves ``task_id`` with ``model``.
 
@@ -143,8 +144,10 @@ def run_agent(
     (isolated container), or ``auto`` (docker if available, else local). When
     ``judges`` is set, the ``human_like`` metric is computed by an LLM judge
     ensemble using ``judge_model`` (defaulting to ``model``). ``suite``/
-    ``suite_id`` tag the run so the leaderboard can group it. Returns a summary
-    dict (also persisted to ``<run_dir>/summary.json``).
+    ``suite_id`` tag the run so the leaderboard can group it. ``max_run_cost``
+    is a per-run USD ceiling on agent spend: the model loop stops once this run's
+    own cost crosses it, and the summary records ``cost_capped``. Returns a
+    summary dict (also persisted to ``<run_dir>/summary.json``).
     """
     task = load_task(task_id, tasks_root)
     provider = provider or get_provider(model)
@@ -178,7 +181,7 @@ def run_agent(
     ]
 
     try:
-        prompt_tokens, completion_tokens, finished = _run_model_loop(
+        prompt_tokens, completion_tokens, finished, cost_capped = _run_model_loop(
             provider,
             tools,
             messages,
@@ -188,6 +191,8 @@ def run_agent(
             run_id,
             deadline,
             effort_meta.as_summary() if effort_meta else None,
+            model=model,
+            max_run_cost=max_run_cost,
         )
         patch = _git_diff(workspace)
         changed_files = _git_changed_files(workspace)
@@ -246,6 +251,7 @@ def run_agent(
             "duration_s": duration_s,
             "started_at": started_at.isoformat(),
             "finished": finished,
+            "cost_capped": cost_capped,
             "manifest": manifest,
             "task_hash": task_hash(task),
             "suite": suite,
@@ -413,7 +419,7 @@ def _budget_exceeded_scores(functional: float, total_tokens: int, steps: int) ->
     )
 
 
-def _run_model_loop(
+def _run_model_loop(  # noqa: PLR0912 — linear ReAct loop with budget + cost guards
     provider: LLMProvider,
     tools: list[dict[str, Any]],
     messages: list[dict[str, Any]],
@@ -423,10 +429,13 @@ def _run_model_loop(
     run_id: str,
     deadline: _RunDeadline,
     effort: dict[str, Any] | None = None,
-) -> tuple[int, int, bool]:
+    model: str | None = None,
+    max_run_cost: float | None = None,
+) -> tuple[int, int, bool, bool]:
     prompt_tokens = 0
     completion_tokens = 0
     finished = False
+    cost_capped = False
 
     for step in range(1, max_steps + 1):
         if not deadline.ensure_time(collector, "llm_request", step):
@@ -454,6 +463,21 @@ def _run_model_loop(
         )
         if not deadline.ensure_time(collector, "llm_response", step):
             break
+
+        # Per-run cost ceiling: once this run's own agent spend crosses the cap,
+        # stop before paying for another (expensive) model call. The partial work
+        # is still verified and scored honestly — "hit the cap" is a real outcome,
+        # not an error. Only enforceable when the model is priced.
+        if max_run_cost is not None and model is not None:
+            run_cost = cost_usd(model, prompt_tokens, completion_tokens)
+            if run_cost is not None and run_cost >= max_run_cost:
+                collector.record(
+                    "cost_cap_exceeded",
+                    {"cost_usd": run_cost, "max_run_cost": max_run_cost, "step": step},
+                )
+                cost_capped = True
+                messages.append(_assistant_message(resp))
+                break
 
         messages.append(_assistant_message(resp))
 
@@ -491,7 +515,7 @@ def _run_model_loop(
             if not deadline.ensure_time(collector, f"tool:{tc.name}", step):
                 break
 
-    return prompt_tokens, completion_tokens, finished
+    return prompt_tokens, completion_tokens, finished, cost_capped
 
 
 _MANIFEST_TOOLS = ("git", "ruff", "bandit", "radon", "go", "node")

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -25,6 +25,7 @@ from harness.cost_estimate import estimate_plan
 from harness.effort import DEFAULT_SWEEP_EFFORTS, parse_efforts
 from harness.leaderboard import aggregate_by_model, scan_leaderboard
 from harness.pricing import is_priced
+from harness.regrade import find_run_dirs, regrade_run
 from harness.report import build_report, to_markdown
 from harness.sandbox.docker_executor import SandboxError
 from harness.suite import SUITE_ALIASES, load_suite, run_suite
@@ -103,6 +104,12 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
     max_cost: float | None = typer.Option(
         None, "--max-cost", help="USD spend cap for a suite run (stops launching new runs)"
     ),
+    max_run_cost: float | None = typer.Option(
+        None,
+        "--max-run-cost",
+        help="Per-run USD ceiling: stop an individual agent run once its own spend "
+        "crosses this (records cost_capped; the partial result is still graded)",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", help="Per-run wall-clock budget in seconds (abort if exceeded)"
     ),
@@ -151,6 +158,17 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
             names = ", ".join(sorted(set(unpriced)))
             console.print(f"[red]error[/red] --max-cost needs priced models; no price for {names}")
             raise typer.Exit(code=1)
+    if max_run_cost is not None:
+        if not (math.isfinite(max_run_cost) and max_run_cost > 0):
+            console.print(
+                f"[red]error[/red] --max-run-cost must be a finite number > 0, got {max_run_cost}"
+            )
+            raise typer.Exit(code=1)
+        if not is_priced(model):
+            console.print(
+                f"[red]error[/red] --max-run-cost needs a priced model; no price for {model}"
+            )
+            raise typer.Exit(code=1)
     if sandbox not in {"local", "docker", "auto"}:
         console.print(f"[red]error[/red] --sandbox must be local|docker|auto, got {sandbox!r}")
         raise typer.Exit(code=1)
@@ -194,6 +212,7 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
         "network": network,
         "timeout_s": timeout,
         "effort": effort,
+        "max_run_cost": max_run_cost,
     }
     pass_at_1: float | None = None
     n_incomplete = 0  # errored + skipped runs (an incomplete suite)
@@ -425,7 +444,7 @@ def _run_suite(
 
 
 @app.command("effort-sweep")
-def effort_sweep(
+def effort_sweep(  # noqa: PLR0912 — CLI entry: option validation + per-effort dispatch
     suite: str = typer.Option(..., "--suite", help="Suite to sweep, e.g. v1"),
     model: str = typer.Option(..., "--model", "-m", help="provider:model e.g. openai:gpt-5.1"),
     efforts: str = typer.Option(
@@ -468,6 +487,12 @@ def effort_sweep(
     max_cost: float | None = typer.Option(
         None, "--max-cost", help="USD spend cap per effort (same semantics as run --suite)"
     ),
+    max_run_cost: float | None = typer.Option(
+        None,
+        "--max-run-cost",
+        help="Per-run USD ceiling: stop an individual agent run once its own spend "
+        "crosses this (records cost_capped; the partial result is still graded)",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", help="Per-run wall-clock budget in seconds (abort if exceeded)"
     ),
@@ -492,6 +517,17 @@ def effort_sweep(
     if max_cost is not None and not (math.isfinite(max_cost) and max_cost > 0):
         console.print(f"[red]error[/red] --max-cost must be a finite number > 0, got {max_cost}")
         raise typer.Exit(code=1)
+    if max_run_cost is not None:
+        if not (math.isfinite(max_run_cost) and max_run_cost > 0):
+            console.print(
+                f"[red]error[/red] --max-run-cost must be a finite number > 0, got {max_run_cost}"
+            )
+            raise typer.Exit(code=1)
+        if not is_priced(model):
+            console.print(
+                f"[red]error[/red] --max-run-cost needs a priced model; no price for {model}"
+            )
+            raise typer.Exit(code=1)
 
     experiment_id = f"experiment-{uuid.uuid4().hex[:8]}"
     console.print(
@@ -523,6 +559,7 @@ def effort_sweep(
                     image=image,
                     network=network,
                     timeout_s=timeout,
+                    max_run_cost=max_run_cost,
                     experiment_id=experiment_id,
                 )
             )
@@ -823,6 +860,81 @@ def list_tasks(
         console.print(i)
     if not ids:
         console.print("no tasks in tasks/v1/ (hello-world synthetic is the demo seed)")
+
+
+@app.command()
+def regrade(
+    target: Path = typer.Argument(  # noqa: B008
+        ...,
+        exists=True,
+        help="A run directory, or a directory of runs (regrades every run under it)",
+    ),
+    tasks_base: Path = typer.Option(  # noqa: B008
+        Path("tasks"), "--tasks-base", help="Root holding task suites (tasks/<suite>/<id>)"
+    ),
+    sandbox: str = typer.Option(
+        "docker", "--sandbox", help="Where to run verifiers: local|docker (docker matches runs)"
+    ),
+    image: str | None = typer.Option(
+        None, "--image", help="Docker sandbox image (default: per-task image)"
+    ),
+    write: bool = typer.Option(
+        True, "--write/--no-write", help="Write regrade.json into each run dir"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit the records as JSON"),
+) -> None:
+    """Re-grade existing run(s) against the current task definition, at zero API cost.
+
+    Rebuilds each run's workspace from the task base plus the captured agent patch,
+    overlays the *current* hidden tests, and re-runs the verifier. Use after
+    changing a task's tests or thresholds to re-score old runs without paying for
+    new model calls.
+    """
+    if sandbox not in {"local", "docker"}:
+        console.print(f"[red]error[/red] --sandbox must be local|docker, got {sandbox!r}")
+        raise typer.Exit(code=1)
+    run_dirs = find_run_dirs(target)
+    if not run_dirs:
+        console.print(f"[red]error[/red] no runs (no summary.json) under {target}")
+        raise typer.Exit(code=1)
+
+    records = []
+    for rd in run_dirs:
+        rec = regrade_run(rd, tasks_base=tasks_base, sandbox=sandbox, image=image, write=write)
+        records.append(rec)
+
+    if json_output:
+        typer.echo(json.dumps(records, indent=2))
+        raise typer.Exit()
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Task")
+    table.add_column("Old", justify="right")
+    table.add_column("New", justify="right")
+    table.add_column("Δ", justify="right")
+    table.add_column("Note")
+    n_changed = 0
+    for rec in records:
+        if rec.get("error"):
+            table.add_row(rec.get("task_id") or rec["run_dir"], "-", "-", "-", f"[red]{rec['error']}[/red]")
+            continue
+        old = rec["old_functional"]
+        new = rec["new_functional"]
+        delta = rec["delta"]
+        if delta:
+            n_changed += 1
+        dstr = "" if delta is None else (f"[green]+{delta}[/green]" if delta > 0 else (f"[red]{delta}[/red]" if delta < 0 else "0"))
+        table.add_row(
+            rec["task_id"],
+            "-" if old is None else f"{old:.3f}",
+            f"{new:.3f}",
+            dstr,
+            rec.get("model") or "",
+        )
+    console.print(table)
+    console.print(
+        f"[cyan]regraded[/cyan] {len(records)} run(s), {n_changed} score change(s), $0 API spend"
+    )
 
 
 if __name__ == "__main__":

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -916,14 +916,24 @@ def regrade(
     n_changed = 0
     for rec in records:
         if rec.get("error"):
-            table.add_row(rec.get("task_id") or rec["run_dir"], "-", "-", "-", f"[red]{rec['error']}[/red]")
+            table.add_row(
+                rec.get("task_id") or rec["run_dir"], "-", "-", "-", f"[red]{rec['error']}[/red]"
+            )
             continue
         old = rec["old_functional"]
         new = rec["new_functional"]
         delta = rec["delta"]
         if delta:
             n_changed += 1
-        dstr = "" if delta is None else (f"[green]+{delta}[/green]" if delta > 0 else (f"[red]{delta}[/red]" if delta < 0 else "0"))
+        dstr = (
+            ""
+            if delta is None
+            else (
+                f"[green]+{delta}[/green]"
+                if delta > 0
+                else (f"[red]{delta}[/red]" if delta < 0 else "0")
+            )
+        )
         table.add_row(
             rec["task_id"],
             "-" if old is None else f"{old:.3f}",

--- a/harness/regrade.py
+++ b/harness/regrade.py
@@ -1,0 +1,188 @@
+"""Re-grade an existing run against the current task definition, at zero API cost.
+
+An agent run is expensive (it calls a model); grading is deterministic and free.
+When a task's hidden tests or thresholds change (e.g. a calibration), the old
+runs do not need to be re-executed against the model — only re-graded. This
+module rebuilds the graded workspace from the task's base snapshot plus the run's
+captured ``final.patch`` (the agent's edits), overlays the *current* hidden
+tests, and re-runs the verifier in the sandbox. No provider is ever called.
+
+The reconstruction (base + agent patch + current tests) is used rather than the
+archived ``workspace/`` directory because that directory still contains the
+*old* hidden tests from the original grading; rebuilding from the patch keeps the
+regrade faithful to whatever the task's tests say now.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from harness.agent.protocol import RunCommandArgs
+from harness.sandbox.docker_executor import DockerToolExecutor
+from harness.sandbox.images import resolve_sandbox_image
+from harness.tasks import load_task, prepare_workspace, task_hash
+from harness.verifier import DEFAULT_TIMEOUT, run_declarative_verifier
+
+DEFAULT_TASKS_BASE = Path("tasks")
+
+
+def resolve_tasks_root(task_id: str, tasks_base: Path = DEFAULT_TASKS_BASE) -> Path | None:
+    """Find the ``tasks/<suite>`` directory that defines ``task_id``.
+
+    Runs record only the task id (and an ephemeral suite name), so on regrade we
+    locate the task by scanning the task roots. Returns ``None`` if not found.
+    """
+    if not tasks_base.is_dir():
+        return None
+    for root in sorted(p for p in tasks_base.iterdir() if p.is_dir()):
+        if (root / task_id / "metadata.json").is_file():
+            return root
+    return None
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    env_names = ("AUTHOR", "COMMITTER")
+    env = {}
+    for who in env_names:
+        env[f"GIT_{who}_NAME"] = "vulcanbench"
+        env[f"GIT_{who}_EMAIL"] = "bot@vulcanbench"
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, **env},
+    )
+
+
+def _apply_patch(workspace: Path, patch: str) -> None:
+    if not patch.strip():
+        return
+    proc = subprocess.run(
+        ["git", "apply", "--whitespace=nowarn"],
+        cwd=workspace,
+        input=patch,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        proc3 = subprocess.run(
+            ["git", "apply", "--3way", "--whitespace=nowarn"],
+            cwd=workspace,
+            input=patch,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc3.returncode != 0:
+            raise RuntimeError(f"patch did not apply: {proc.stderr.strip()}")
+
+
+def _docker_runner(executor: DockerToolExecutor):
+    def run(cmd: str, _workspace: Path, timeout: int) -> int:
+        try:
+            res = executor.run_command(RunCommandArgs(cmd=cmd, timeout=timeout))
+        except Exception:
+            return 124
+        return int(res.get("exit_code", 1))
+
+    return run
+
+
+def regrade_run(
+    run_dir: Path,
+    tasks_base: Path = DEFAULT_TASKS_BASE,
+    sandbox: str = "docker",
+    image: str | None = None,
+    write: bool = True,
+) -> dict[str, Any]:
+    """Re-grade one run directory against the current task definition.
+
+    Returns a record with old vs new functional score and per-test results.
+    Writes ``regrade.json`` into ``run_dir`` when ``write`` is set. Never calls a
+    model provider.
+    """
+    summary_path = run_dir / "summary.json"
+    if not summary_path.is_file():
+        return {"run_dir": str(run_dir), "error": "no summary.json"}
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    task_id = summary.get("task_id")
+    old_functional = (summary.get("scores") or {}).get("functional")
+
+    root = resolve_tasks_root(task_id, tasks_base)
+    if root is None:
+        return {"run_dir": str(run_dir), "task_id": task_id, "error": "task not found in tasks/"}
+    task = load_task(task_id, root)
+
+    if task.tests_spec is None:
+        return {"run_dir": str(run_dir), "task_id": task_id, "error": "task is not test-graded"}
+
+    patch_path = run_dir / "final.patch"
+    if not patch_path.is_file():
+        return {"run_dir": str(run_dir), "task_id": task_id, "error": "no final.patch to regrade"}
+    patch = patch_path.read_text(encoding="utf-8")
+
+    workspace = run_dir / "regrade_workspace"
+    if workspace.exists():
+        shutil.rmtree(workspace)
+    try:
+        prepare_workspace(task, workspace)
+        _git(["init", "-q"], workspace)
+        _git(["add", "-A"], workspace)
+        _git(["commit", "-q", "--allow-empty", "-m", "base"], workspace)
+        _apply_patch(workspace, patch)
+    except RuntimeError as e:
+        return {"run_dir": str(run_dir), "task_id": task_id, "old_functional": old_functional,
+                "error": str(e)}
+
+    executor: DockerToolExecutor | None = None
+    try:
+        if sandbox == "docker":
+            resolved_image = resolve_sandbox_image(task, image)
+            executor = DockerToolExecutor(workspace, image=resolved_image, network=False)
+            runner = _docker_runner(executor)
+        else:
+            runner = None  # host runner (default in run_declarative_verifier)
+        payload = run_declarative_verifier(task, workspace, runner=runner, timeout=DEFAULT_TIMEOUT)
+    finally:
+        if executor is not None:
+            close = getattr(executor, "close", None)
+            if callable(close):
+                close()
+
+    new_functional = float((payload.get("scores") or {}).get("functional", 0.0))
+    record = {
+        "run_dir": str(run_dir),
+        "run_id": summary.get("run_id"),
+        "task_id": task_id,
+        "model": summary.get("model"),
+        "old_functional": old_functional,
+        "new_functional": new_functional,
+        "delta": None if old_functional is None else round(new_functional - old_functional, 4),
+        "fail_to_pass": payload.get("fail_to_pass"),
+        "pass_to_pass": payload.get("pass_to_pass"),
+        "old_task_hash": summary.get("task_hash"),
+        "new_task_hash": task_hash(task),
+        "regraded_at": datetime.now(UTC).isoformat(),
+        "sandbox": sandbox,
+    }
+    if write:
+        (run_dir / "regrade.json").write_text(json.dumps(record, indent=2), encoding="utf-8")
+    # Clean the throwaway workspace to avoid bloating the run dir.
+    shutil.rmtree(workspace, ignore_errors=True)
+    return record
+
+
+def find_run_dirs(target: Path) -> list[Path]:
+    """Return run directories under ``target`` (or ``[target]`` if it is one)."""
+    if (target / "summary.json").is_file():
+        return [target]
+    return sorted(p.parent for p in target.glob("**/summary.json"))

--- a/harness/regrade.py
+++ b/harness/regrade.py
@@ -27,7 +27,7 @@ from harness.agent.protocol import RunCommandArgs
 from harness.sandbox.docker_executor import DockerToolExecutor
 from harness.sandbox.images import resolve_sandbox_image
 from harness.tasks import load_task, prepare_workspace, task_hash
-from harness.verifier import DEFAULT_TIMEOUT, run_declarative_verifier
+from harness.verifier import DEFAULT_TIMEOUT, Runner, run_declarative_verifier
 
 DEFAULT_TASKS_BASE = Path("tasks")
 
@@ -86,7 +86,7 @@ def _apply_patch(workspace: Path, patch: str) -> None:
             raise RuntimeError(f"patch did not apply: {proc.stderr.strip()}")
 
 
-def _docker_runner(executor: DockerToolExecutor):
+def _docker_runner(executor: DockerToolExecutor) -> Runner:
     def run(cmd: str, _workspace: Path, timeout: int) -> int:
         try:
             res = executor.run_command(RunCommandArgs(cmd=cmd, timeout=timeout))
@@ -140,8 +140,12 @@ def regrade_run(
         _git(["commit", "-q", "--allow-empty", "-m", "base"], workspace)
         _apply_patch(workspace, patch)
     except RuntimeError as e:
-        return {"run_dir": str(run_dir), "task_id": task_id, "old_functional": old_functional,
-                "error": str(e)}
+        return {
+            "run_dir": str(run_dir),
+            "task_id": task_id,
+            "old_functional": old_functional,
+            "error": str(e),
+        }
 
     executor: DockerToolExecutor | None = None
     try:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -470,9 +470,7 @@ def test_run_agent_stops_at_per_run_cost_cap(
             # -> ~$2.25 per step, so a $5 cap should trip on the 3rd step.
             return LLMResponse(
                 content=None,
-                tool_calls=[
-                    ToolInvocation(id="t", name="run_command", arguments={"cmd": "true"})
-                ],
+                tool_calls=[ToolInvocation(id="t", name="run_command", arguments={"cmd": "true"})],
                 usage=TokenUsage(prompt_tokens=200_000, completion_tokens=50_000),
             )
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -432,3 +432,107 @@ def test_changed_files_are_captured_before_hidden_tests(
     assert captured == [["m.py"]]
     assert (run_dir / "workspace" / "t_f2p.py").exists()
     assert "t_f2p.py" not in (run_dir / "final.patch").read_text(encoding="utf-8")
+
+
+def test_run_agent_stops_at_per_run_cost_cap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-run cost ceiling halts the loop once the run's own spend crosses it.
+
+    The partial result is still verified/scored, ``cost_capped`` is set, and a
+    ``cost_cap_exceeded`` event is recorded. Uses a priced model so a real cost
+    can be computed, and a provider that never finishes (keeps requesting tools).
+    """
+
+    class FakeExecutor:
+        def execute(self, call):  # type: ignore[no-untyped-def]
+            return SimpleNamespace(result={"ok": True}, error=None)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(loop_mod, "_make_executor", lambda *a, **k: FakeExecutor())
+    monkeypatch.setattr(loop_mod, "_verify", lambda *a, **k: (0.0, {"scores": {"functional": 0.0}}))
+
+    class GrindProvider(LLMProvider):
+        @property
+        def name(self) -> str:
+            return "anthropic"
+
+        def complete(
+            self,
+            messages: list[dict[str, Any]],
+            tools: list[dict[str, Any]],
+            timeout_s: float | None = None,
+            effort: str | None = None,
+        ) -> LLMResponse:
+            # Every call is expensive and never finishes: opus-4-8 at $5/$25 per M
+            # -> ~$2.25 per step, so a $5 cap should trip on the 3rd step.
+            return LLMResponse(
+                content=None,
+                tool_calls=[
+                    ToolInvocation(id="t", name="run_command", arguments={"cmd": "true"})
+                ],
+                usage=TokenUsage(prompt_tokens=200_000, completion_tokens=50_000),
+            )
+
+    res = run_agent(
+        task_id="hello-world",
+        model="anthropic:claude-opus-4-8",
+        output_dir=tmp_path,
+        provider=GrindProvider("grind"),
+        tasks_root=Path("tasks/v1"),
+        judges=False,
+        max_run_cost=5.0,
+    )
+
+    summary = res["summary"]
+    assert summary["cost_capped"] is True
+    assert summary["finished"] is False
+    # Overshoot is bounded by one step: the cap trips as soon as cost crosses $5.
+    assert 5.0 <= summary["cost_usd"] <= 5.0 + 2.5
+    types = [
+        json.loads(line)["type"]
+        for line in (tmp_path / res["run_id"] / "trace.jsonl").read_text().splitlines()
+    ]
+    assert "cost_cap_exceeded" in types
+
+
+def test_run_agent_no_cost_cap_runs_to_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a cap, the same expensive provider runs until it finishes."""
+
+    class FakeExecutor:
+        def execute(self, call):  # type: ignore[no-untyped-def]
+            return SimpleNamespace(result={"ok": True}, error=None)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(loop_mod, "_make_executor", lambda *a, **k: FakeExecutor())
+    monkeypatch.setattr(loop_mod, "_verify", lambda *a, **k: (0.0, {"scores": {"functional": 0.0}}))
+
+    class FinishProvider(LLMProvider):
+        @property
+        def name(self) -> str:
+            return "anthropic"
+
+        def complete(self, messages, tools, timeout_s=None, effort=None):  # type: ignore[no-untyped-def]
+            return LLMResponse(
+                content="FINISH: done",
+                usage=TokenUsage(prompt_tokens=200_000, completion_tokens=50_000),
+            )
+
+    res = run_agent(
+        task_id="hello-world",
+        model="anthropic:claude-opus-4-8",
+        output_dir=tmp_path,
+        provider=FinishProvider("finish"),
+        tasks_root=Path("tasks/v1"),
+        judges=False,
+        max_run_cost=None,
+    )
+    summary = res["summary"]
+    assert summary["cost_capped"] is False
+    assert summary["finished"] is True

--- a/tests/test_regrade.py
+++ b/tests/test_regrade.py
@@ -1,0 +1,149 @@
+"""Tests for zero-API-cost re-grading of existing runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from harness.regrade import find_run_dirs, regrade_run, resolve_tasks_root
+from harness.tasks import load_task, prepare_workspace
+
+pytestmark = pytest.mark.skipif(shutil.which("pytest") is None, reason="pytest not on PATH")
+
+
+def _make_task(suite: Path, f2p_expected: int = 2) -> None:
+    """A tiny Python task under ``suite/fix-f`` whose base code returns 0."""
+    task = suite / "fix-f"
+    (task / "repo").mkdir(parents=True)
+    (task / "tests").mkdir(parents=True)
+    (task / "repo" / "m.py").write_text("def f():\n    return 0\n")
+    (task / "tests" / "t_f2p.py").write_text(
+        f"from m import f\n\ndef test_expected():\n    assert f() == {f2p_expected}\n"
+    )
+    (task / "tests" / "t_p2p.py").write_text(
+        "from m import f\n\ndef test_int():\n    assert isinstance(f(), int)\n"
+    )
+    (task / "metadata.json").write_text(
+        json.dumps(
+            {
+                "id": "fix-f",
+                "category": "bug_fix",
+                "languages": ["python"],
+                "difficulty": "trivial",
+                "created": "2026-07-05",
+                "source": "hand-authored",
+                "decontamination_notes": "fixture",
+                "tests": {
+                    "fail_to_pass": [{"name": "exp", "cmd": "python -m pytest t_f2p.py -q"}],
+                    "pass_to_pass": [{"name": "int", "cmd": "python -m pytest t_p2p.py -q"}],
+                },
+            }
+        )
+    )
+    (task / "issue.md").write_text("make f return the expected value")
+
+
+def _make_run(run_dir: Path, patch: str, old_functional: float) -> None:
+    """Fabricate a completed-run directory: a summary + the agent's captured patch."""
+    run_dir.mkdir(parents=True)
+    (run_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_dir.name,
+                "task_id": "fix-f",
+                "model": "mock:test",
+                "scores": {"functional": old_functional},
+                "task_hash": "old",
+            }
+        )
+    )
+    (run_dir / "final.patch").write_text(patch)
+
+
+def _patch_that_returns(suite: Path, tmp: Path, value: int) -> str:
+    """Build a git patch (like a real run's final.patch) that makes f() return ``value``."""
+    task = load_task("fix-f", suite)
+    ws = prepare_workspace(task, tmp / "patchws")
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t",
+           "GIT_COMMITTER_EMAIL": "t@t"}
+    full = {**os.environ, **env}
+    subprocess.run(["git", "init", "-q"], cwd=ws, check=True, env=full)
+    subprocess.run(["git", "add", "-A"], cwd=ws, check=True, env=full)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=ws, check=True, env=full)
+    (ws / "m.py").write_text(f"def f():\n    return {value}\n")
+    subprocess.run(["git", "add", "-A"], cwd=ws, check=True, env=full)
+    diff = subprocess.run(
+        ["git", "diff", "--cached"], cwd=ws, capture_output=True, text=True, check=True, env=full
+    )
+    shutil.rmtree(ws)
+    return diff.stdout
+
+
+def test_regrade_reconstructs_and_scores_the_patch(tmp_path: Path) -> None:
+    suite = tmp_path / "tasks"
+    _make_task(suite, f2p_expected=2)
+    patch = _patch_that_returns(suite, tmp_path, value=2)  # a correct fix
+
+    run_dir = tmp_path / "runs" / "fix-f-abc123"
+    _make_run(run_dir, patch, old_functional=0.0)
+
+    rec = regrade_run(run_dir, tasks_base=tmp_path, sandbox="local", write=True)
+
+    assert rec["old_functional"] == 0.0
+    assert rec["new_functional"] == 1.0  # base(0) + patch(2) + tests(==2) -> passes
+    assert rec["delta"] == 1.0
+    assert rec["fail_to_pass"]  # per-test detail present
+    # regrade.json is written back into the run dir, and the throwaway ws is cleaned.
+    assert (run_dir / "regrade.json").is_file()
+    assert not (run_dir / "regrade_workspace").exists()
+
+
+def test_regrade_reflects_a_changed_test(tmp_path: Path) -> None:
+    """The whole point: changing the task's tests re-scores an old run for free."""
+    suite = tmp_path / "tasks"
+    _make_task(suite, f2p_expected=2)
+    patch = _patch_that_returns(suite, tmp_path, value=2)
+    run_dir = tmp_path / "runs" / "fix-f-def456"
+    _make_run(run_dir, patch, old_functional=1.0)
+
+    # Raise the bar: the test now demands f() == 3. The old patch (returns 2) fails.
+    (suite / "fix-f" / "tests" / "t_f2p.py").write_text(
+        "from m import f\n\ndef test_expected():\n    assert f() == 3\n"
+    )
+
+    rec = regrade_run(run_dir, tasks_base=tmp_path, sandbox="local", write=False)
+    assert rec["old_functional"] == 1.0
+    assert rec["new_functional"] == 0.0
+    assert rec["delta"] == -1.0
+
+
+def test_resolve_tasks_root_and_find_run_dirs(tmp_path: Path) -> None:
+    suite = tmp_path / "tasks"
+    _make_task(suite)
+    assert resolve_tasks_root("fix-f", tmp_path) == suite
+    assert resolve_tasks_root("nope", tmp_path) is None
+
+    runs = tmp_path / "runs"
+    _make_run(runs / "a", "", 0.0)
+    _make_run(runs / "b", "", 0.0)
+    found = find_run_dirs(runs)
+    assert {p.name for p in found} == {"a", "b"}
+    # Pointing directly at a single run dir returns just that one.
+    assert find_run_dirs(runs / "a") == [runs / "a"]
+
+
+def test_regrade_missing_patch_is_reported(tmp_path: Path) -> None:
+    suite = tmp_path / "tasks"
+    _make_task(suite)
+    run_dir = tmp_path / "runs" / "fix-f-nopatch"
+    run_dir.mkdir(parents=True)
+    (run_dir / "summary.json").write_text(
+        json.dumps({"run_id": "x", "task_id": "fix-f", "scores": {"functional": 0.0}})
+    )
+    rec = regrade_run(run_dir, tasks_base=tmp_path, sandbox="local")
+    assert "no final.patch" in rec["error"]

--- a/tests/test_regrade.py
+++ b/tests/test_regrade.py
@@ -69,8 +69,12 @@ def _patch_that_returns(suite: Path, tmp: Path, value: int) -> str:
     """Build a git patch (like a real run's final.patch) that makes f() return ``value``."""
     task = load_task("fix-f", suite)
     ws = prepare_workspace(task, tmp / "patchws")
-    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t",
-           "GIT_COMMITTER_EMAIL": "t@t"}
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
     full = {**os.environ, **env}
     subprocess.run(["git", "init", "-q"], cwd=ws, check=True, env=full)
     subprocess.run(["git", "add", "-A"], cwd=ws, check=True, env=full)


### PR DESCRIPTION
Two cost-control features for the self-funded benchmarking workflow. Both come straight out of this week's spend analysis: failing hard-tier runs ruminate to the step cap ($6-9 each, producing no code), and every grading change forced a full re-run of the whole matrix.

## 1. `--max-run-cost` — per-run hard ceiling

A per-run USD cap on agent spend. The model loop stops once a run's own cost crosses the value (overshoot bounded by a single model call), the summary records `cost_capped: true` with a `cost_cap_exceeded` trace event, and the partial result is **still verified and scored** — hitting the cap is an honest outcome, not an error.

- Wired into `run` (single `--task` or `--suite`) and `effort-sweep`; requires a priced model.
- Turns an "$8 DNF" into a "$2.50 DNF" with no loss of signal — exactly the Fable rumination case from Report 5.

Unit-tested at three thresholds with a priced model + stub provider: cap trips at \$2.25 (cap 2.0), \$6.75 (cap 5.0), and runs the full \$22.50 uncapped.

## 2. `regrade` — re-score existing runs at \$0 API cost

Grading is deterministic, so when a task's hidden tests or thresholds change you don't need to re-run the model — just re-grade. `regrade` rebuilds each run's workspace from the task base plus the captured agent patch (`final.patch`), overlays the **current** hidden tests, and re-runs the verifier in the sandbox. No provider is ever called.

```bash
vulcanbench regrade runs/<run-id> --sandbox docker   # one run
vulcanbench regrade runs/ --sandbox docker           # every run under a dir
```

Prints old → new functional per run and writes `regrade.json`. Reconstruction is verified faithful: an unchanged-test regrade of a real run reproduced its original 0.833 score exactly. Re-scoring the pre-calibration Leiden runs against the current tests (the \$28 re-screen from this week) now costs \$0.

## Tests & docs
- `tests/test_agent_loop.py`: cost-cap trip + no-cap control.
- `tests/test_regrade.py`: reconstruct-and-score, changed-test re-score, run-dir discovery, missing-patch error path.
- `docs/QUICKSTART.md`: cost-control and re-grade notes.
- Full suite green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)