### PR TITLE
Add `compare`: assemble model×effort matrix from cached runs (freeze baselines)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -116,5 +116,23 @@ It prints old → new functional per run and writes `regrade.json` into each run
 dir. Use it to re-score historical runs against a calibrated task without paying
 for a single new model call.
 
+**Add a model to a comparison without re-running the baselines.** Because grading
+is deterministic and every run records the `task_hash` it was scored against, a
+model×effort comparison is a *query over cached runs*, not a re-run. `compare`
+builds the matrix for a frozen suite from `./runs`, excluding any run scored
+against an older task definition (so results stay apples-to-apples):
+
+```bash
+vulcanbench compare --suite v2                     # complete cells only
+vulcanbench compare --suite v2 --incomplete        # show gaps + how to fill them
+```
+
+The suite is "frozen" implicitly by its task hashes (`compare` prints a short
+version id); change a task and its cached runs go stale and drop out. To add a
+model, run just that one model against the suite, then re-run `compare` — the
+baselines come from cache. That turns a new-model report from a full-matrix
+re-run into a single new column, and pairs naturally with `--max-run-cost` to
+bound the cost of that one column.
+
 See the full example in the README and `docs/ARCHITECTURE.md`. To add your own
 task: `docs/TASK_CONTRIBUTION.md`.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -21,6 +21,7 @@ from harness import __version__
 from harness.agent.loop import run_agent
 from harness.agent.providers import ProviderError
 from harness.calibration import calibrate_tasks, calibration_to_markdown
+from harness.compare import build_matrix
 from harness.cost_estimate import estimate_plan
 from harness.effort import DEFAULT_SWEEP_EFFORTS, parse_efforts
 from harness.leaderboard import aggregate_by_model, scan_leaderboard
@@ -945,6 +946,85 @@ def regrade(
     console.print(
         f"[cyan]regraded[/cyan] {len(records)} run(s), {n_changed} score change(s), $0 API spend"
     )
+
+
+@app.command()
+def compare(
+    suite: str = typer.Option(..., "--suite", help="Suite to compare, e.g. v2"),
+    runs_dir: Path = typer.Option(  # noqa: B008
+        Path("./runs"), "--runs-dir", "-o", help="Where cached runs live"
+    ),
+    tasks_base: Path = typer.Option(  # noqa: B008
+        Path("tasks"), "--tasks-base", help="Root holding task suites"
+    ),
+    incomplete: bool = typer.Option(
+        False, "--incomplete/--complete-only", help="Also show cells missing some tasks"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit the matrix as JSON"),
+) -> None:
+    """Build a model x effort comparison for a frozen suite from cached runs only.
+
+    Re-runs nothing: every cell comes from ``./runs``, filtered to the suite's
+    current task hashes (stale runs, scored against an older task definition, are
+    excluded). To add a model to the comparison, run just that one model against
+    the suite, then re-run ``compare`` — the baselines are read from cache.
+    """
+    try:
+        matrix = build_matrix(suite, runs_dir=runs_dir, tasks_base=tasks_base)
+    except FileNotFoundError as e:
+        console.print(f"[red]error[/red] {e}")
+        raise typer.Exit(code=1) from e
+
+    if json_output:
+        typer.echo(json.dumps(matrix, indent=2))
+        raise typer.Exit()
+
+    console.print(
+        f"[bold]{matrix['suite']}[/bold] "
+        f"[dim]frozen @ {matrix['version']} · {matrix['n_tasks']} tasks[/dim]"
+    )
+    cells = matrix["cells"] if incomplete else [c for c in matrix["cells"] if c["complete"]]
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Model (effort)")
+    table.add_column("Pass@1", justify="right")
+    table.add_column("Cost", justify="right")
+    table.add_column("Coverage", justify="right")
+    for c in cells:
+        cov = f"{c['n_present']}/{c['n_total']}"
+        cov_str = cov if c["complete"] else f"[yellow]{cov}[/yellow]"
+        table.add_row(
+            f"{c['model']} ({c['effort']})",
+            "-" if c["pass_at_1"] is None else f"{c['pass_at_1']:.3f}",
+            "?" if c["cost_usd"] is None else f"${c['cost_usd']:.2f}",
+            cov_str,
+        )
+    console.print(table)
+
+    if matrix["n_stale_excluded"]:
+        console.print(
+            f"[dim]{matrix['n_stale_excluded']} stale run(s) excluded "
+            f"(scored against an older task definition; re-run or `regrade`).[/dim]"
+        )
+
+    # Show what a new column needs: incomplete cells and how to fill them.
+    gaps = [c for c in matrix["cells"] if not c["complete"]]
+    if gaps and not incomplete:
+        console.print("[dim]Incomplete cells hidden; pass --incomplete to see them.[/dim]")
+    for c in gaps if incomplete else []:
+        miss = c["missing_tasks"]
+        console.print(
+            f"[yellow]incomplete[/yellow] {c['model']} ({c['effort']}): "
+            f"missing {len(miss)}/{c['n_total']} task(s)"
+        )
+        if c["n_present"] == 0:
+            eff = "" if c["effort"] == "-" else f" --effort {c['effort']}"
+            console.print(
+                f"  fill: vulcanbench run --suite {suite} -m {c['model']}{eff} --sandbox docker"
+            )
+        else:
+            shown = ", ".join(miss[:6]) + (" …" if len(miss) > 6 else "")
+            console.print(f"  missing: {shown}")
 
 
 if __name__ == "__main__":

--- a/harness/compare.py
+++ b/harness/compare.py
@@ -1,0 +1,134 @@
+"""Assemble a model x effort comparison from cached runs, re-running nothing.
+
+Grading is deterministic and every run records the ``task_hash`` it was scored
+against, so a comparison across models does not require re-running baselines: it
+is a query over ``./runs``. This module builds that query.
+
+A suite is "frozen" implicitly by its task hashes. ``suite_version`` summarizes
+the current task set as a single short hash; any cached run whose recorded
+``task_hash`` no longer matches its task is *stale* and excluded, so a comparison
+only ever mixes results from the same frozen definition. Adding a model to a
+report is therefore: run that one model, then rebuild the matrix from cache. The
+baselines are never paid for twice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from harness.leaderboard import current_task_hashes, mark_stale, summary_to_row
+from harness.suite import DEFAULT_TASKS_BASE, load_suite
+
+
+def _scan_runs_recursive(runs_dir: Path) -> list[dict[str, Any]]:
+    """One leaderboard row per run under ``runs_dir`` at any nesting depth.
+
+    ``harness.leaderboard.load_summaries`` only looks one level deep; sweeps and
+    experiments nest run dirs under a sub-directory, so compare discovers
+    ``summary.json`` recursively.
+    """
+    rows: list[dict[str, Any]] = []
+    if not runs_dir.exists():
+        return rows
+    for sj in sorted(runs_dir.glob("**/summary.json")):
+        try:
+            s = json.loads(sj.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        s.setdefault("run_id", sj.parent.name)
+        rows.append(summary_to_row(s, fallback_run_id=sj.parent.name))
+    return rows
+
+
+def suite_version(suite: str, tasks_base: Path = DEFAULT_TASKS_BASE) -> dict[str, Any]:
+    """Return the frozen identity of a suite: its task set and a version hash.
+
+    The version is a hash of the sorted ``(task_id, task_hash)`` pairs, so it
+    changes exactly when the suite's task set or any task's scoring definition
+    changes. Two runs sharing a suite version are directly comparable.
+    """
+    s = load_suite(suite, tasks_base)
+    hashes = current_task_hashes(s.tasks_root)
+    pairs = sorted((tid, hashes.get(tid, "?")) for tid in s.task_ids)
+    digest = hashlib.sha256("\n".join(f"{tid}:{h}" for tid, h in pairs).encode()).hexdigest()
+    return {
+        "suite": suite,
+        "version": digest[:12],
+        "n_tasks": len(s.task_ids),
+        "task_ids": list(s.task_ids),
+        "task_hashes": {tid: h for tid, h in pairs},
+    }
+
+
+def _cell_key(row: dict[str, Any]) -> tuple[str, str]:
+    return (row.get("model") or "?", row.get("effort_requested") or "-")
+
+
+def build_matrix(
+    suite: str,
+    runs_dir: Path = Path("./runs"),
+    tasks_base: Path = DEFAULT_TASKS_BASE,
+) -> dict[str, Any]:
+    """Build the model x effort comparison for ``suite`` from cached runs.
+
+    Each cell aggregates the non-stale cached runs for one (model, effort) over
+    the suite's tasks: pass@1 (mean over tasks of the per-task solve rate), total
+    cached cost, and coverage (how many of the suite's tasks have a fresh run). A
+    cell is ``complete`` when every suite task is covered. Incomplete cells list
+    the tasks still to run — those, and only those, need new model calls.
+    """
+    ver = suite_version(suite, tasks_base)
+    suite_tasks = set(ver["task_ids"])
+    s = load_suite(suite, tasks_base)
+
+    rows = [r for r in _scan_runs_recursive(runs_dir) if r.get("task_id") in suite_tasks]
+    mark_stale(rows, s.tasks_root)
+    fresh = [r for r in rows if r.get("task_stale") is not True]
+    n_stale_excluded = sum(1 for r in rows if r.get("task_stale") is True)
+
+    # Group fresh runs into (model, effort) cells, then by task within a cell.
+    cells: dict[tuple[str, str], dict[str, list[dict[str, Any]]]] = {}
+    for r in fresh:
+        cells.setdefault(_cell_key(r), {}).setdefault(str(r.get("task_id")), []).append(r)
+
+    cell_records: list[dict[str, Any]] = []
+    for (model, effort), by_task in sorted(cells.items()):
+        present = [t for t in suite_tasks if t in by_task]
+        # pass@1: mean over covered tasks of the per-task solve rate.
+        solve_rates = []
+        cost = 0.0
+        cost_known = True
+        for t in present:
+            runs = by_task[t]
+            solved = sum(1 for x in runs if (x.get("functional") or 0) >= 1.0)
+            solve_rates.append(solved / len(runs))
+            for x in runs:
+                c = x.get("cost_usd")
+                if c is None:
+                    cost_known = False
+                else:
+                    cost += c
+        missing = sorted(suite_tasks - set(present))
+        cell_records.append(
+            {
+                "model": model,
+                "effort": effort,
+                "n_present": len(present),
+                "n_total": len(suite_tasks),
+                "complete": len(present) == len(suite_tasks),
+                "pass_at_1": round(sum(solve_rates) / len(solve_rates), 4) if solve_rates else None,
+                "cost_usd": round(cost, 4) if cost_known else None,
+                "missing_tasks": missing,
+            }
+        )
+
+    cell_records.sort(key=lambda c: (-(c["pass_at_1"] or -1), c["model"], c["effort"]))
+    return {
+        **ver,
+        "runs_dir": str(runs_dir),
+        "n_stale_excluded": n_stale_excluded,
+        "cells": cell_records,
+    }

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,143 @@
+"""Tests for the cached-run comparison / freeze-baselines flow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness.compare import build_matrix, suite_version
+from harness.tasks import load_task, task_hash
+
+
+def _make_task(suite: Path, task_id: str, expected: int = 2) -> None:
+    task = suite / task_id
+    (task / "repo").mkdir(parents=True)
+    (task / "tests").mkdir(parents=True)
+    (task / "repo" / "m.py").write_text("def f():\n    return 0\n")
+    (task / "tests" / "t.py").write_text(
+        f"from m import f\n\ndef test_it():\n    assert f() == {expected}\n"
+    )
+    (task / "metadata.json").write_text(
+        json.dumps(
+            {
+                "id": task_id,
+                "category": "bug_fix",
+                "languages": ["python"],
+                "difficulty": "trivial",
+                "created": "2026-07-05",
+                "source": "hand-authored",
+                "decontamination_notes": "fixture",
+                "tests": {
+                    "fail_to_pass": [{"name": "it", "cmd": "python -m pytest t.py -q"}],
+                    "pass_to_pass": [],
+                },
+            }
+        )
+    )
+    (task / "issue.md").write_text("fix f")
+
+
+def _make_suite(base: Path, name: str, task_ids: list[str]) -> Path:
+    suite = base / name
+    for tid in task_ids:
+        _make_task(suite, tid)
+    return suite
+
+
+def _write_run(
+    runs: Path, task_id: str, model: str, effort: str, functional: float, cost: float, thash: str
+) -> None:
+    d = runs / f"{task_id}-{model}-{effort}".replace(":", "_")
+    d.mkdir(parents=True)
+    (d / "summary.json").write_text(
+        json.dumps(
+            {
+                "run_id": d.name,
+                "task_id": task_id,
+                "model": model,
+                "effort": {"requested": effort},
+                "scores": {"functional": functional},
+                "cost_usd": cost,
+                "task_hash": thash,
+            }
+        )
+    )
+
+
+def test_suite_version_changes_with_task_definition(tmp_path: Path) -> None:
+    _make_suite(tmp_path, "s", ["a", "b"])
+    v1 = suite_version("s", tmp_path)["version"]
+    # Re-reading the same tasks yields the same version.
+    assert suite_version("s", tmp_path)["version"] == v1
+    # Changing a task's test changes its hash -> the suite version changes.
+    (tmp_path / "s" / "a" / "tests" / "t.py").write_text(
+        "from m import f\n\ndef test_it():\n    assert f() == 3\n"
+    )
+    assert suite_version("s", tmp_path)["version"] != v1
+
+
+def test_build_matrix_assembles_cells_from_cache(tmp_path: Path) -> None:
+    suite = _make_suite(tmp_path, "s", ["a", "b"])
+    ha = task_hash(load_task("a", suite))
+    hb = task_hash(load_task("b", suite))
+    runs = tmp_path / "runs"
+
+    # Opus solves both at low; Fable solves one of two.
+    _write_run(runs, "a", "opus", "low", 1.0, 0.5, ha)
+    _write_run(runs, "b", "opus", "low", 1.0, 0.7, hb)
+    _write_run(runs, "a", "fable", "low", 1.0, 2.0, ha)
+    _write_run(runs, "b", "fable", "low", 0.0, 3.0, hb)
+
+    m = build_matrix("s", runs_dir=runs, tasks_base=tmp_path)
+    cells = {(c["model"], c["effort"]): c for c in m["cells"]}
+
+    opus = cells[("opus", "low")]
+    assert opus["complete"] is True
+    assert opus["pass_at_1"] == 1.0
+    assert opus["cost_usd"] == 1.2  # 0.5 + 0.7
+
+    fable = cells[("fable", "low")]
+    assert fable["complete"] is True
+    assert fable["pass_at_1"] == 0.5  # 1 of 2 tasks solved
+    assert m["n_stale_excluded"] == 0
+
+
+def test_stale_runs_are_excluded_when_a_task_changes(tmp_path: Path) -> None:
+    suite = _make_suite(tmp_path, "s", ["a", "b"])
+    ha = task_hash(load_task("a", suite))
+    hb = task_hash(load_task("b", suite))
+    runs = tmp_path / "runs"
+    _write_run(runs, "a", "opus", "low", 1.0, 0.5, ha)
+    _write_run(runs, "b", "opus", "low", 1.0, 0.7, hb)
+
+    # Recalibrate task "a": its recorded run is now stale and must be dropped,
+    # leaving the opus cell incomplete (only b covered).
+    (suite / "a" / "tests" / "t.py").write_text(
+        "from m import f\n\ndef test_it():\n    assert f() == 99\n"
+    )
+
+    m = build_matrix("s", runs_dir=runs, tasks_base=tmp_path)
+    assert m["n_stale_excluded"] == 1
+    opus = next(c for c in m["cells"] if c["model"] == "opus")
+    assert opus["complete"] is False
+    assert opus["n_present"] == 1
+    assert opus["missing_tasks"] == ["a"]
+
+
+def test_new_model_is_a_single_new_column(tmp_path: Path) -> None:
+    """The core value: baselines come from cache; a new model is one added cell."""
+    suite = _make_suite(tmp_path, "s", ["a", "b"])
+    ha = task_hash(load_task("a", suite))
+    hb = task_hash(load_task("b", suite))
+    runs = tmp_path / "runs"
+    # Cached baseline (opus) — never re-run.
+    _write_run(runs, "a", "opus", "high", 1.0, 0.5, ha)
+    _write_run(runs, "b", "opus", "high", 1.0, 0.7, hb)
+    assert len(build_matrix("s", runs_dir=runs, tasks_base=tmp_path)["cells"]) == 1
+
+    # Add a new model's runs; the baseline is untouched, the matrix gains one cell.
+    _write_run(runs, "a", "newmodel", "high", 1.0, 4.0, ha)
+    _write_run(runs, "b", "newmodel", "high", 0.0, 5.0, hb)
+    cells = build_matrix("s", runs_dir=runs, tasks_base=tmp_path)["cells"]
+    assert len(cells) == 2
+    assert {c["model"] for c in cells} == {"opus", "newmodel"}


### PR DESCRIPTION
The **"freeze baselines, one new column"** cost fix. A model comparison is a *query over `./runs`*, not a re-run of the whole matrix — because grading is deterministic and every run records the `task_hash` it was scored against, baselines never need to be paid for twice.

## What it does

`vulcanbench compare --suite v2` builds the model × effort table entirely from cached runs:

```
v2 frozen @ a44fc27c45f6 · 10 tasks
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┓
┃ Model (effort)                    ┃ Pass@1 ┃   Cost ┃ Coverage ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━┩
│ anthropic:claude-opus-4-8 (high)  │  0.900 │ $23.09 │    10/10 │
│ anthropic:claude-opus-4-8 (low)   │  0.900 │  $2.27 │    10/10 │
│ zai:glm-5.2 (high)                │  0.800 │ $15.87 │    10/10 │
│ anthropic:claude-sonnet-5 (high)  │  0.739 │ $49.26 │    10/10 │
└───────────────────────────────────┴────────┴────────┴──────────┘
```

On the real `./runs` it assembles an 8-config comparison (Fable / Opus / Sonnet 5 / GPT-5.5 / GLM-5.2 across efforts) from runs cached across past benchmarks — **zero re-runs**.

## How "freeze" works

The suite is frozen *implicitly* by its task hashes — no manual step. `suite_version` prints a short id derived from the sorted `task_id:task_hash` pairs; it changes exactly when the task set or a task's scoring definition changes. Any cached run whose recorded `task_hash` no longer matches its task is **stale and excluded**, so a comparison only ever mixes apples-to-apples results. (After the recent Leiden/pennylane calibration, those cached runs correctly drop out until re-run or `regrade`d.)

## Adding a model = one new column

Run just the new model against the suite, then re-run `compare`; the baselines come from cache. Incomplete cells name the exact missing tasks and print the fill command. Pairs with `--max-run-cost` to bound the cost of that single column. **New-model report: ~$70 full-matrix re-run → ~$10 for one column.**

## Tests & docs
- `tests/test_compare.py`: suite-version stability + change-on-recalibration; cell assembly (pass@1/cost/coverage); stale-run exclusion; new-model-is-one-cell.
- `docs/QUICKSTART.md`: compare/freeze workflow.
- Full suite green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)