### PR TITLE
Add `--only-missing`: resume a suite run, filling only uncached cells

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -134,5 +134,16 @@ baselines come from cache. That turns a new-model report from a full-matrix
 re-run into a single new column, and pairs naturally with `--max-run-cost` to
 bound the cost of that one column.
 
+`--only-missing` closes the loop: on a suite run it skips tasks that already have
+enough fresh cached runs for that model+effort and launches only the gaps, so an
+interrupted or partial column is *resumed* rather than re-run. Stale cached runs
+(scored against an older task definition) are ignored and re-run.
+
+```bash
+# run a column; if it's interrupted or you add tasks, re-run to fill only the gaps
+vulcanbench run --suite v2 -m anthropic:claude-opus-4-8 --effort high \
+  --only-missing --max-run-cost 2.50 --sandbox docker
+```
+
 See the full example in the README and `docs/ARCHITECTURE.md`. To add your own
 task: `docs/TASK_CONTRIBUTION.md`.

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -111,6 +111,12 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
         help="Per-run USD ceiling: stop an individual agent run once its own spend "
         "crosses this (records cost_capped; the partial result is still graded)",
     ),
+    only_missing: bool = typer.Option(
+        False,
+        "--only-missing",
+        help="Suite runs: skip tasks that already have enough fresh cached runs for "
+        "this model+effort, running only the gaps (resume a partial column)",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", help="Per-run wall-clock budget in seconds (abort if exceeded)"
     ),
@@ -170,6 +176,9 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
                 f"[red]error[/red] --max-run-cost needs a priced model; no price for {model}"
             )
             raise typer.Exit(code=1)
+    if only_missing and suite is None:
+        console.print("[red]error[/red] --only-missing applies to suite runs (use --suite)")
+        raise typer.Exit(code=1)
     if sandbox not in {"local", "docker", "auto"}:
         console.print(f"[red]error[/red] --sandbox must be local|docker|auto, got {sandbox!r}")
         raise typer.Exit(code=1)
@@ -220,7 +229,14 @@ def run(  # noqa: PLR0912, PLR0915 — CLI entry: option declarations + linear g
     try:
         if suite is not None:
             pass_at_1, n_incomplete = _run_suite(
-                suite, model, output_dir, run_kwargs, repeat, max_concurrency, max_cost
+                suite,
+                model,
+                output_dir,
+                run_kwargs,
+                repeat,
+                max_concurrency,
+                max_cost,
+                only_missing,
             )
         else:
             pass_at_1, n_incomplete = _run_single(task, model, output_dir, run_kwargs, repeat)  # type: ignore[arg-type]
@@ -408,13 +424,15 @@ def _run_suite(
     repeat: int,
     max_concurrency: int,
     max_cost: float | None = None,
+    only_missing: bool = False,
 ) -> tuple[float | None, int]:
     """Run a suite; returns (pass@1, n_incomplete) where n_incomplete counts
     errored + budget-skipped runs."""
     suffix = f" x{repeat}" if repeat > 1 else ""
     par = f" ({max_concurrency}-way parallel)" if max_concurrency > 1 else ""
     cap = f" (budget ${max_cost})" if max_cost is not None else ""
-    console.print(f"[cyan]running suite[/cyan] {suite}{suffix}{par}{cap} with {model} ...")
+    resume = " (only-missing)" if only_missing else ""
+    console.print(f"[cyan]running suite[/cyan] {suite}{suffix}{par}{cap}{resume} with {model} ...")
     result = run_suite(
         suite,
         model,
@@ -422,8 +440,15 @@ def _run_suite(
         repeat=repeat,
         max_concurrency=max_concurrency,
         max_cost=max_cost,
+        only_missing=only_missing,
         **run_kwargs,
     )
+    covered = result.get("covered_cached") or []
+    if covered:
+        console.print(
+            f"[dim]only-missing: reused {len(covered)} cached task(s), "
+            f"ran {result.get('n_runs', 0)} new run(s).[/dim]"
+        )
     n_errors = len(result.get("errors") or [])
     n_skipped = result.get("n_skipped", 0)
     if n_errors:
@@ -494,6 +519,12 @@ def effort_sweep(  # noqa: PLR0912 — CLI entry: option validation + per-effort
         help="Per-run USD ceiling: stop an individual agent run once its own spend "
         "crosses this (records cost_capped; the partial result is still graded)",
     ),
+    only_missing: bool = typer.Option(
+        False,
+        "--only-missing",
+        help="Skip tasks that already have enough fresh cached runs per effort, "
+        "running only the gaps (resume a partial sweep)",
+    ),
     timeout: float | None = typer.Option(
         None, "--timeout", help="Per-run wall-clock budget in seconds (abort if exceeded)"
     ),
@@ -552,6 +583,7 @@ def effort_sweep(  # noqa: PLR0912 — CLI entry: option validation + per-effort
                     repeat=repeat,
                     max_concurrency=max_concurrency,
                     max_cost=max_cost,
+                    only_missing=only_missing,
                     effort=effort,
                     max_steps=max_steps,
                     judges=judges,

--- a/harness/compare.py
+++ b/harness/compare.py
@@ -19,6 +19,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from harness.effort import normalize_effort
 from harness.leaderboard import current_task_hashes, mark_stale, summary_to_row
 from harness.suite import DEFAULT_TASKS_BASE, load_suite
 
@@ -65,6 +66,37 @@ def suite_version(suite: str, tasks_base: Path = DEFAULT_TASKS_BASE) -> dict[str
 
 def _cell_key(row: dict[str, Any]) -> tuple[str, str]:
     return (row.get("model") or "?", row.get("effort_requested") or "-")
+
+
+def fresh_run_counts(
+    task_ids: list[str],
+    model: str,
+    effort: str | None,
+    runs_dir: Path,
+    tasks_root: Path,
+) -> dict[str, int]:
+    """Count non-stale cached runs per task for one (model, effort) cell.
+
+    A run counts only if its task still matches the current definition on disk
+    (its recorded ``task_hash`` is fresh). Used by the suite runner to skip tasks
+    that already have enough cached runs, so ``--only-missing`` fills just the
+    gaps instead of re-running a whole column.
+    """
+    want_effort = normalize_effort(effort)
+    wanted = set(task_ids)
+    rows = [
+        r
+        for r in _scan_runs_recursive(runs_dir)
+        if r.get("task_id") in wanted
+        and r.get("model") == model
+        and normalize_effort(r.get("effort_requested")) == want_effort
+    ]
+    mark_stale(rows, tasks_root)
+    counts: dict[str, int] = dict.fromkeys(task_ids, 0)
+    for r in rows:
+        if r.get("task_stale") is not True:
+            counts[str(r.get("task_id"))] += 1
+    return counts
 
 
 def build_matrix(

--- a/harness/suite.py
+++ b/harness/suite.py
@@ -108,7 +108,7 @@ def load_suite(name: str, tasks_base: Path = DEFAULT_TASKS_BASE) -> Suite:
     return Suite(name=name, tasks_root=tasks_root, task_ids=task_ids)
 
 
-def run_suite(  # noqa: PLR0915 — linear scheduler: validation + budget loop + summary assembly
+def run_suite(  # noqa: PLR0912, PLR0915 — linear scheduler: validation + budget loop + summary
     name: str,
     model: str,
     output_dir: Path = Path("./runs"),
@@ -116,6 +116,7 @@ def run_suite(  # noqa: PLR0915 — linear scheduler: validation + budget loop +
     repeat: int = 1,
     max_concurrency: int = 1,
     max_cost: float | None = None,
+    only_missing: bool = False,
     **run_kwargs: Any,
 ) -> dict[str, Any]:
     """Run ``model`` against every task in the suite, ``repeat`` times each.
@@ -148,7 +149,28 @@ def run_suite(  # noqa: PLR0915 — linear scheduler: validation + budget loop +
     suite_id = f"suite-{uuid.uuid4().hex[:8]}"
     started_at = datetime.now(UTC)
 
-    units = [task_id for task_id in suite.task_ids for _ in range(repeat)]
+    # ``only_missing`` reuses cached, non-stale runs for this model+effort and
+    # launches only enough runs to top each task up to ``repeat`` — so a partly
+    # finished column is resumed instead of re-run from scratch.
+    covered: list[str] = []
+    if only_missing:
+        from harness.compare import fresh_run_counts  # noqa: PLC0415 — avoid import cycle
+
+        counts = fresh_run_counts(
+            list(suite.task_ids),
+            model,
+            run_kwargs.get("effort"),
+            output_dir,
+            suite.tasks_root,
+        )
+        units = []
+        for task_id in suite.task_ids:
+            need = max(0, repeat - counts.get(task_id, 0))
+            units.extend([task_id] * need)
+            if need == 0:
+                covered.append(task_id)
+    else:
+        units = [task_id for task_id in suite.task_ids for _ in range(repeat)]
 
     def _run_one(task_id: str) -> dict[str, Any]:
         res = run_agent(
@@ -236,6 +258,8 @@ def run_suite(  # noqa: PLR0915 — linear scheduler: validation + budget loop +
         "n_tasks": len(suite.task_ids),
         "n_runs": len(task_results),
         "n_skipped": len(skipped),
+        "only_missing": only_missing,
+        "covered_cached": covered,
         "tasks": task_results,
         "errors": errors,
         "skipped": skipped,

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from harness.compare import build_matrix, suite_version
+from harness.compare import build_matrix, fresh_run_counts, suite_version
 from harness.tasks import load_task, task_hash
 
 
@@ -47,7 +47,12 @@ def _make_suite(base: Path, name: str, task_ids: list[str]) -> Path:
 def _write_run(
     runs: Path, task_id: str, model: str, effort: str, functional: float, cost: float, thash: str
 ) -> None:
-    d = runs / f"{task_id}-{model}-{effort}".replace(":", "_")
+    base = f"{task_id}-{model}-{effort}".replace(":", "_")
+    d = runs / base
+    n = 1
+    while d.exists():
+        d = runs / f"{base}-{n}"
+        n += 1
     d.mkdir(parents=True)
     (d / "summary.json").write_text(
         json.dumps(
@@ -141,3 +146,21 @@ def test_new_model_is_a_single_new_column(tmp_path: Path) -> None:
     cells = build_matrix("s", runs_dir=runs, tasks_base=tmp_path)["cells"]
     assert len(cells) == 2
     assert {c["model"] for c in cells} == {"opus", "newmodel"}
+
+
+def test_fresh_run_counts_filters_model_effort_and_staleness(tmp_path: Path) -> None:
+    suite = _make_suite(tmp_path, "s", ["a", "b"])
+    ha = task_hash(load_task("a", suite))
+    hb = task_hash(load_task("b", suite))
+    runs = tmp_path / "runs"
+
+    _write_run(runs, "a", "opus", "low", 1.0, 0.5, ha)
+    _write_run(runs, "a", "opus", "low", 1.0, 0.5, ha)  # a second attempt for a
+    _write_run(runs, "b", "opus", "low", 1.0, 0.7, hb)
+    _write_run(runs, "a", "opus", "high", 1.0, 0.9, ha)  # different effort
+    _write_run(runs, "a", "fable", "low", 1.0, 2.0, ha)  # different model
+    _write_run(runs, "b", "opus", "low", 1.0, 0.7, "STALE")  # stale hash
+
+    counts = fresh_run_counts(["a", "b"], "opus", "low", runs, suite)
+    assert counts["a"] == 2  # two fresh opus-low runs for a
+    assert counts["b"] == 1  # the stale one is not counted

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -320,3 +321,67 @@ def test_parallel_error_containment(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert result["errors"][0]["task_id"] == "task-b"
     assert {t["task_id"] for t in result["tasks"]} == {"task-a"}
     assert result["aggregate"][0]["n_tasks"] == 1  # only task-a produced a run
+
+
+def test_run_suite_only_missing_reuses_and_fills(tmp_path: Path) -> None:
+    """--only-missing reuses fresh cached runs and launches only the gaps."""
+    base = tmp_path / "tasks"
+    _make_task(base / "demo", "task-a")
+    _make_task(base / "demo", "task-b")
+    out = tmp_path / "runs"
+
+    # Full first pass: two runs.
+    first = run_suite("demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False)
+    assert first["n_runs"] == 2
+
+    # only_missing with both already cached: nothing new runs, both covered.
+    reuse = run_suite(
+        "demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False, only_missing=True
+    )
+    assert reuse["n_runs"] == 0
+    assert set(reuse["covered_cached"]) == {"task-a", "task-b"}
+
+    # Drop task-a's cached run: only_missing now runs exactly task-a.
+    for d in out.glob("task-a-*"):
+        shutil.rmtree(d)
+    gap = run_suite(
+        "demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False, only_missing=True
+    )
+    assert gap["n_runs"] == 1
+    assert {t["task_id"] for t in gap["tasks"]} == {"task-a"}
+    assert gap["covered_cached"] == ["task-b"]
+
+
+def test_run_suite_only_missing_ignores_stale_cache(tmp_path: Path) -> None:
+    """A cached run scored against an older task definition is not reused."""
+    base = tmp_path / "tasks"
+    _make_task(base / "demo", "task-a")
+    out = tmp_path / "runs"
+    run_suite("demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False)
+
+    # Change the task's prompt -> its hash changes -> the cached run is stale.
+    (base / "demo" / "task-a" / "issue.md").write_text("Completely different task now.")
+    res = run_suite(
+        "demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False, only_missing=True
+    )
+    assert res["n_runs"] == 1  # stale cache ignored, task re-run
+    assert res["covered_cached"] == []
+
+
+def test_run_suite_only_missing_tops_up_repeats(tmp_path: Path) -> None:
+    """With repeat>N and N fresh runs cached, only the shortfall is launched."""
+    base = tmp_path / "tasks"
+    _make_task(base / "demo", "task-a")
+    out = tmp_path / "runs"
+    run_suite("demo", "mock:synthetic", output_dir=out, tasks_base=base, judges=False, repeat=1)
+
+    res = run_suite(
+        "demo",
+        "mock:synthetic",
+        output_dir=out,
+        tasks_base=base,
+        judges=False,
+        repeat=3,
+        only_missing=True,
+    )
+    assert res["n_runs"] == 2  # 1 already cached, top up to 3


### PR DESCRIPTION
Completes the freeze-baselines workflow. `compare` tells you which (model, effort) cells are incomplete; **`--only-missing`** fills exactly those gaps instead of re-running the whole column.

## Behavior

On a suite run, `--only-missing` reuses fresh cached runs for the same model+effort and launches only the shortfall to bring each task up to `--repeat`:

```bash
vulcanbench run --suite v2 -m anthropic:claude-opus-4-8 --effort high \
  --only-missing --max-run-cost 2.50 --sandbox docker
# only-missing: reused 8 cached task(s), ran 2 new run(s).
```

- **Resume:** an interrupted or partial column continues from where it stopped.
- **Stale-aware:** a cached run scored against an older task definition (task_hash mismatch) is ignored and re-run, so resumed columns stay apples-to-apples.
- **Repeat-aware:** with `--repeat 3` and 1 fresh run cached, it launches 2.
- Available on `run` (suite-only) and `effort-sweep`; pairs with `--max-run-cost` so the resumed column is both gap-only and cost-bounded.

## Implementation
- `harness/compare.py`: `fresh_run_counts(...)` counts non-stale cached runs per task for one model+effort cell (recursive run discovery, normalized effort match).
- `harness/suite.py`: `run_suite(..., only_missing=False)` builds the work list from the shortfall and records `covered_cached`. Lazy import breaks the suite↔compare cycle.

## Tests & docs
- `tests/test_suite.py`: reuse-and-fill, partial resume, stale-cache re-run, repeat top-up.
- `tests/test_compare.py`: `fresh_run_counts` model/effort/staleness filtering.
- `docs/QUICKSTART.md`: resume flow. Full suite green; ruff + mypy clean.

Verified end-to-end with the mock provider: full pass runs 2, `--only-missing` reuses 2 / runs 0, and after deleting one cached run it reuses 1 / runs 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)