### PR TITLE
docs: note the runs-dir consolidation caveat for --only-missing and compare

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -145,5 +145,16 @@ vulcanbench run --suite v2 -m anthropic:claude-opus-4-8 --effort high \
   --only-missing --max-run-cost 2.50 --sandbox docker
 ```
 
+> **Keep runs in one place.** Both the cache reuse (`--only-missing`) and the
+> comparison (`compare`) only see runs under the directory they scan — the
+> `--output-dir` of the run for `--only-missing`, and `--runs-dir` for `compare`
+> (both default to `./runs`, scanned recursively). Runs written to *other*
+> directories are invisible to that lookup, so `--only-missing` will re-run a
+> cell whose cached result lives elsewhere, and `compare` will show it as
+> missing. Point every run at the same `--output-dir` (or consolidate run dirs
+> under one root before comparing) so the cache lookup sees the full history.
+> Nesting is fine — sub-directories are discovered — the runs just have to be
+> under the one root you scan.
+
 See the full example in the README and `docs/ARCHITECTURE.md`. To add your own
 task: `docs/TASK_CONTRIBUTION.md`.


### PR DESCRIPTION
Documents a real footgun in the cache-reuse flow: both `--only-missing` and `compare` only see runs under the single directory they scan (`--output-dir` and `--runs-dir` respectively, default `./runs`, scanned recursively). Runs written to *other* directories are invisible to the lookup — so `--only-missing` re-runs a cell whose cached result lives elsewhere, and `compare` reports it as missing.

Adds a callout to `docs/QUICKSTART.md`: keep every run under one `--output-dir` (nesting is fine), or consolidate run dirs under one root before comparing.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)