### PR TITLE
Release v0.6.0: frontier-hard tier + cost-efficient reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ engineering tasks. VulcanBench measures how models perform across reasoning
 effort, language, codebase scale, and task complexity — with full traces,
 reproducible scoring, and a local dashboard.
 
-**v0.5.1** — 52 gold-verified tasks, tool-calling agent (mock / OpenAI /
-Anthropic / Z.ai), Docker sandbox, pre-run cost estimates with bundled priors
-(`vulcanbench estimate`), `v1-compare` suite, five-metric scoring, suite runs,
-and HTML replay.
+**v0.6.0** — adds a **frontier-hard task tier** (net-new-algorithm tasks from
+real merged PRs, each screened to defeat low-effort frontier models) and
+**cost-efficient reporting**: per-run cost caps (`--max-run-cost`),
+cached-baseline comparison (`compare`), free re-grading after task edits
+(`regrade`), and gap-only resume (`--only-missing`) — so a new-model report is
+one column, not a full-matrix re-run. Builds on v0.5's 52 gold-verified tasks,
+tool-calling agent (mock / OpenAI / Anthropic / Z.ai), Docker sandbox, pre-run
+cost estimates, five-metric scoring, and HTML replay.
 See [docs/QUICKSTART.md](docs/QUICKSTART.md) to get started.
 
 ## One-command setup

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcanbench"
-version = "0.5.1"
+version = "0.6.0"
 description = "VulcanBench v1 - open-source LLM benchmarking harness for realistic software engineering tasks"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 import harness.cli as cli_mod
+from harness import __version__
 from harness.cli import app
 
 runner = CliRunner()
@@ -18,7 +19,7 @@ runner = CliRunner()
 def test_version() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert "0.5.1" in result.output
+    assert __version__ in result.output
 
 
 def test_help() -> None:


### PR DESCRIPTION
Bumps `0.5.1 → 0.6.0` (feature release) across `harness/__init__.py`, `pyproject.toml`, and the README blurb.

## What's new since 0.5.1

**Frontier-hard task tier.** Net-new-algorithm tasks from real post-cutoff merged PRs (networkx Leiden, sqlglot canonical-name rewrite, three pennylane resource-estimation templates), each individually screened to defeat low-effort frontier models, plus the calibration that made their grading fair-hard rather than under-specified.

**Cost-efficient reporting** — a new-model report becomes one column, not a full-matrix re-run:
- `--max-run-cost` — per-run cost ceiling (stop + grade the partial result)
- `compare` — assemble the model × effort matrix from cached runs (baselines never re-run)
- `regrade` — re-score existing runs against the current tests for $0
- `--only-missing` — resume a suite run, filling only the uncached cells

All of the above shipped in PRs #9–#14 and are already on `main`; this just stamps the version.

Verified: `vulcanbench --version` reports `0.6.0`, no lingering `0.5.1` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)