### PR TITLE
Fix step count: use agent iterations, not trace events

### DIFF
--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -2018,6 +2018,7 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
         # Killed by the budget/cost watchdog (partial work still counts), or
         # the CLI died without reporting, approximate usage from the stream.
         outcome.prompt_tokens, outcome.completion_tokens = _fold_usage_totals(usage_by_msg.values())
+        outcome.num_turns = len(usage_by_msg)
         if not (killed["timeout"] or killed["cost"]):
             tail = "".join(stderr_chunks)[-500:].strip()
             raise ProviderError(

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -458,7 +458,7 @@ def _execute_agent(
             outcome.completion_tokens,
             outcome.finished,
             outcome.cost_capped,
-            outcome.num_turns or 0,
+            outcome.num_turns if outcome.num_turns is not None else 0,
             outcome,
         )
     assert provider is not None  # resolved by _resolve_run_engine for non-CLI specs
@@ -643,7 +643,7 @@ def _run_model_loop(  # noqa: PLR0912, linear ReAct loop with budget + cost guar
     effort: dict[str, Any] | None = None,
     model: str | None = None,
     max_run_cost: float | None = None,
-) -> tuple[int, int, bool, bool]:
+) -> tuple[int, int, bool, bool, int]:
     prompt_tokens = 0
     completion_tokens = 0
     finished = False
@@ -651,9 +651,9 @@ def _run_model_loop(  # noqa: PLR0912, linear ReAct loop with budget + cost guar
     actual_steps = 0
 
     for step in range(1, max_steps + 1):
-        actual_steps = step
         if not deadline.ensure_time(collector, "llm_request", step):
             break
+        actual_steps = step
         request_data: dict[str, Any] = {"step": step, "messages": len(messages)}
         if effort is not None:
             request_data["effort"] = effort

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -200,23 +200,25 @@ def run_agent(  # noqa: PLR0915
     ]
 
     try:
-        prompt_tokens, completion_tokens, finished, cost_capped, cli_outcome = _execute_agent(
-            cli_adapter=cli_adapter,
-            model=model,
-            provider=provider,
-            task=task,
-            tools=tools,
-            messages=messages,
-            effective_max_steps=effective_max_steps,
-            collector=collector,
-            executor=executor,
-            run_id=run_id,
-            run_dir=run_dir,
-            workspace=workspace,
-            deadline=deadline,
-            effort_meta=effort_meta,
-            network=network,
-            max_run_cost=max_run_cost,
+        prompt_tokens, completion_tokens, finished, cost_capped, actual_steps, cli_outcome = (
+            _execute_agent(
+                cli_adapter=cli_adapter,
+                model=model,
+                provider=provider,
+                task=task,
+                tools=tools,
+                messages=messages,
+                effective_max_steps=effective_max_steps,
+                collector=collector,
+                executor=executor,
+                run_id=run_id,
+                run_dir=run_dir,
+                workspace=workspace,
+                deadline=deadline,
+                effort_meta=effort_meta,
+                network=network,
+                max_run_cost=max_run_cost,
+            )
         )
         patch = _git_diff(workspace)
         changed_files = _git_changed_files(workspace)
@@ -245,7 +247,7 @@ def run_agent(  # noqa: PLR0915
     scores = _evaluate_with_budget(
         functional=functional,
         total_tokens=total_tokens,
-        steps=collector.step,
+        steps=actual_steps,
         workspace=workspace,
         patch=patch,
         changed_files=changed_files,
@@ -297,7 +299,7 @@ def run_agent(  # noqa: PLR0915
     summary = collector.finalize(
         scores,
         {
-            "steps": collector.step,
+            "steps": actual_steps,
             "total_tokens": total_tokens,
             "tokens": {
                 "prompt": prompt_tokens,
@@ -432,7 +434,7 @@ def _execute_agent(
     effort_meta: Any,
     network: bool,
     max_run_cost: float | None,
-) -> tuple[int, int, bool, bool, CliAgentOutcome | None]:
+) -> tuple[int, int, bool, bool, int, CliAgentOutcome | None]:
     """Run the agent phase: the vendor CLI in the workspace, or the model loop."""
     if cli_adapter is not None:
         _, cli_model = parse_model_spec(model)
@@ -456,10 +458,11 @@ def _execute_agent(
             outcome.completion_tokens,
             outcome.finished,
             outcome.cost_capped,
+            outcome.num_turns or 0,
             outcome,
         )
     assert provider is not None  # resolved by _resolve_run_engine for non-CLI specs
-    prompt_tokens, completion_tokens, finished, cost_capped = _run_model_loop(
+    prompt_tokens, completion_tokens, finished, cost_capped, actual_steps = _run_model_loop(
         provider,
         tools,
         messages,
@@ -472,7 +475,7 @@ def _execute_agent(
         model=model,
         max_run_cost=max_run_cost,
     )
-    return prompt_tokens, completion_tokens, finished, cost_capped, None
+    return prompt_tokens, completion_tokens, finished, cost_capped, actual_steps, None
 
 
 def _compute_cost(
@@ -645,8 +648,10 @@ def _run_model_loop(  # noqa: PLR0912, linear ReAct loop with budget + cost guar
     completion_tokens = 0
     finished = False
     cost_capped = False
+    actual_steps = 0
 
     for step in range(1, max_steps + 1):
+        actual_steps = step
         if not deadline.ensure_time(collector, "llm_request", step):
             break
         request_data: dict[str, Any] = {"step": step, "messages": len(messages)}
@@ -724,7 +729,7 @@ def _run_model_loop(  # noqa: PLR0912, linear ReAct loop with budget + cost guar
             if not deadline.ensure_time(collector, f"tool:{tc.name}", step):
                 break
 
-    return prompt_tokens, completion_tokens, finished, cost_capped
+    return prompt_tokens, completion_tokens, finished, cost_capped, actual_steps
 
 
 _MANIFEST_TOOLS = ("git", "ruff", "bandit", "radon", "go", "node")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -72,6 +72,35 @@ def test_run_agent_solves_hello_world(tmp_path: Path) -> None:
     assert (run_dir / "replay.html").exists()
 
 
+def test_run_agent_steps_count_iterations_not_trace_events(tmp_path: Path) -> None:
+    """summary['steps'] must be agent loop iterations, not the trace-event counter.
+
+    collector.step increments on every record() (llm_request, llm_response,
+    tool_call, tool_observation, and so on). Using it for scoring under-reports
+    efficiency whenever a step emits multiple events.
+    """
+    res = run_agent(
+        task_id="hello-world",
+        model="mock:synthetic",
+        output_dir=tmp_path,
+        tasks_root=Path("tasks/v1"),
+        judges=False,
+    )
+    run_dir = tmp_path / res["run_id"]
+    summary = res["summary"]
+    events = [
+        json.loads(line)
+        for line in (run_dir / "trace.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    llm_requests = sum(1 for e in events if e["type"] == "llm_request")
+    assert llm_requests >= 1
+    assert summary["steps"] == llm_requests
+    # Tool/metric events inflate the trace counter past the iteration count.
+    assert len(events) > llm_requests
+    assert summary["steps"] < len(events)
+
+
 def test_run_agent_records_mock_effort_metadata(tmp_path: Path) -> None:
     res = run_agent(
         task_id="hello-world",


### PR DESCRIPTION
## Bug

`collector.step` is a monotonically increasing counter incremented on every
trace event (llm_request, llm_response, tool_call + tool_observation for each
tool, etc.). It was used everywhere as the runs `steps` metric — the summary,
the leaderboard, and the efficiency score.

For a 10-step agent run with ~3 tools/step this reported ~70 steps instead of
10, systematically under-reporting the efficiency score on every run (step_factor
= 1.0 − steps / 100 gave ~0.30 instead of the correct ~0.90).

## Fix

- `_run_model_loop` now returns the actual loop iteration count alongside the
  existing token/cost accounting. The loop variable already tracks this.
- `_execute_agent` threads the real step count through for both provider and CLI
  agent paths.
- For CLI agent runs `CliAgentOutcome.num_turns` provides the real count (the
  CLI result message reports it). For budget-killed runs it falls back to
  `len(usage_by_msg)` (the number of assistant messages received from the
  stream before termination).
- Summary, efficiency scoring, and all downstream consumers use the real step
  count instead of `collector.step`.

## Verification

A hello-world mock run:
- Steps reported: **4** (agent iterations) — was 25 (trace events)
- Efficiency: **0.9824** — was ~0.919
