### PR TITLE
Set up Cloud Agent dev environment (AGENTS.md + update script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+VulcanBench is an open-source LLM benchmarking harness. It has three parts:
+
+- **CLI harness** (`vulcanbench`, package `harness/`) — the core product; runs
+  benchmark tasks and writes results under `./runs/`.
+- **Backend API** (`backend/app.py`, FastAPI) — serves run data at `/api/*`.
+- **Dashboard** (`dashboard/`, Next.js) — reads the API and renders the
+  leaderboard / tasks / run traces.
+
+Standard commands live in the `Makefile` (`make help`), `README.md`,
+`docs/QUICKSTART.md`, `CONTRIBUTING.md`, and `dashboard/README.md`.
+
+## Cursor Cloud specific instructions
+
+The update script already installs Python deps (`.venv` via `make setup` plus the
+`[backend]` extra) and dashboard deps (`npm ci` in `dashboard/`). Activate the
+venv with `source .venv/bin/activate` before using `vulcanbench`.
+
+- **Run Python tests via `make test` (or `make ci`), not `.venv/bin/pytest`
+  directly.** The harness and several tests shell out to `ruff`, `bandit`, and
+  `pytest` by name. The `Makefile` puts `.venv/bin` on `PATH`; invoking the venv
+  binary directly instead leaves those off `PATH`, so many tests skip
+  ("ruff not installed" / "pytest not on PATH") and coverage drops below the 80%
+  gate — a false failure. With `PATH` set correctly the full fast suite passes
+  (~83% coverage).
+- **Docker is not installed in this environment.** Real model runs and the
+  `--sandbox docker` default require it, as do `make sandbox-image*` and
+  `make validate-tasks-docker`. For offline work use the deterministic mock model
+  with the local sandbox:
+  `vulcanbench run --task hello-world --model mock:synthetic --sandbox local`.
+  Real providers (`openai:`, `anthropic:`, `zai:`, `kimi:`) additionally need the
+  matching API key (`OPENAI_API_KEY`, etc.); none are set here.
+- **Backend runs DB-free by default.** `uvicorn backend.app:app --port 8000`
+  reads `./runs/` from the filesystem (`/api/health` reports
+  `"store":"filesystem"`); no Postgres needed. A DB is only used when
+  `DATABASE_URL` is set (optional; `docker compose up db` needs Docker).
+- **Dashboard** (`cd dashboard && npm run dev`, port 3000) fetches the backend at
+  `http://localhost:8000` by default and shows an offline banner if it is down,
+  so start the backend first. Note: deleting/recreating `dashboard/node_modules`
+  while `npm run dev` is running breaks the live server — restart it afterward.
+- **Lint/typecheck currently fail on pre-existing issues, not env problems.**
+  `ruff`/`mypy` are unpinned (`>=`), so the newest versions install; against them
+  `main` already fails `ruff check` (import order in `tests/test_providers.py`)
+  and `mypy` (unused `type: ignore` in `alembic/env.py`). The tooling itself
+  works — these are pre-existing repo lint failures.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the VulcanBench development environment for Cursor Cloud Agents and documents durable, non-obvious run/test caveats. Adds a top-level `AGENTS.md` (the only code change). The startup update script installs deps only; no product code was modified.

## Type of change
- [x] Documentation only / DX (dev-environment setup)

## What was set up

- Installed `python3.12-venv` (system), then `make setup` (`.venv` + `.[dev,test]`) and the `.[backend]` extra.
- Installed dashboard deps with `npm ci` in `dashboard/`.
- Verified all three components run end-to-end.

## Update script (runs on VM startup)

```
make setup
.venv/bin/pip install -e ".[backend]"
npm ci --prefix dashboard
```

## Verification

| Component | Command | Result |
|-----------|---------|--------|
| CLI harness | `vulcanbench run --task hello-world --model mock:synthetic --sandbox local` | `total=0.974`, run written to `./runs/` |
| Tests | `make test` | 484 passed, 83.13% coverage |
| Dashboard lint | `npm run lint` (dashboard) | clean |
| Dashboard build | `npm run build` (dashboard) | build succeeds |
| Backend API | `uvicorn backend.app:app --port 8000` | `/api/health` = `{"status":"ok","store":"filesystem"}`; leaderboard serves the run |
| Dashboard dev | `npm run dev` (port 3000) | renders leaderboard/tasks from live API |

The CLI run's result flows through the backend and is displayed on the dashboard leaderboard, confirming the full stack works.

## Notes (also in AGENTS.md)

- Run Python tests via `make test`/`make ci`, not `.venv/bin/pytest` directly — the harness shells out to `ruff`/`bandit`/`pytest` by name and the `Makefile` puts `.venv/bin` on `PATH`; skipping that yields false skips and a sub-80% coverage failure.
- Docker is not installed; use `mock:synthetic` + `--sandbox local` for offline runs. Real providers need API keys.
- Backend is DB-free by default (reads `./runs/`); Postgres is optional.
- Pre-existing: `main`'s CI is already red on `ruff`/`mypy` (unpinned tool version drift: import order in `tests/test_providers.py`, unused `type: ignore` in `alembic/env.py`) — not an environment problem, and left unmodified per scope.

## Checklist
- [x] No secrets or large binaries committed
- [x] Docs updated (AGENTS.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cabdb19-9b69-4cf7-a59b-2f2ca6419cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cabdb19-9b69-4cf7-a59b-2f2ca6419cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

