### PR TITLE
Add Claude Opus 5 pricing (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `oss-ty-m3-02/08/11/14`) that every model solved. Two easy anchors per language
   are kept; `oss-py-m2-00` and `oss-py-m3-00` were re-specified as honest anchors.
 
+## [0.7.1] - 2026-07-24
+
+### Added
+
+- Built-in pricing for `anthropic:claude-opus-5` at Anthropic's published standard
+  rates of $5 per million input tokens and $25 per million output tokens. Cost
+  estimates, reports, `--max-cost`, and `--max-run-cost` now support Opus 5.
+
 ## [0.7.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ engineering tasks. VulcanBench measures how models perform across reasoning
 effort, language, codebase scale, and task complexity — with full traces,
 reproducible scoring, and a local dashboard.
 
-**v0.7.0** — adds a **Qwen / DashScope provider** (`qwen:qwen3.7-plus` and friends)
-so Alibaba Cloud models can be benchmarked like OpenAI / Anthropic / Z.ai / Kimi.
-Builds on v0.6's frontier-hard task tier and cost-efficient reporting
+**v0.7.1** — adds built-in **Claude Opus 5 pricing** (`anthropic:claude-opus-5`)
+so estimates, reports, and cost caps use Anthropic's $5/M input and $25/M output
+rates. Builds on v0.7's Qwen / DashScope provider and v0.6's frontier-hard task
+tier and cost-efficient reporting
 (`--max-run-cost`, `compare`, `regrade`, `--only-missing`), and on v0.5's 52
 gold-verified tasks, tool-calling agent, Docker sandbox, pre-run cost estimates,
 five-metric scoring, and HTML replay.

--- a/harness/__init__.py
+++ b/harness/__init__.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __all__ = ["__version__"]

--- a/harness/pricing.py
+++ b/harness/pricing.py
@@ -38,6 +38,7 @@ PRICES: dict[str, dict[str, float]] = {
     "openai:o3": {"input": 2.00, "output": 8.00},
     "openai:o4-mini": {"input": 1.10, "output": 4.40},
     "anthropic:claude-fable-5": {"input": 10.00, "output": 50.00},
+    "anthropic:claude-opus-5": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-8": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-7": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-6": {"input": 5.00, "output": 25.00},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vulcanbench"
-version = "0.7.0"
+version = "0.7.1"
 description = "VulcanBench v1 - open-source LLM benchmarking harness for realistic software engineering tasks"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ runner = CliRunner()
 def test_version() -> None:
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
-    assert __version__ == "0.7.0"
+    assert __version__ == "0.7.1"
     assert __version__ in result.output
 
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -65,6 +65,9 @@ def test_anthropic_frontier_models_priced() -> None:
     # Sonnet 5 standard pricing: input 3.00/1M, output 15.00/1M -> 1M+1M = 18.00.
     assert pricing.is_priced("anthropic:claude-sonnet-5")
     assert pricing.cost_usd("anthropic:claude-sonnet-5", 1_000_000, 1_000_000) == 18.0
+    # Opus 5 retains Opus 4.8 pricing: input 5.00/1M, output 25.00/1M -> 30.00.
+    assert pricing.is_priced("anthropic:claude-opus-5")
+    assert pricing.cost_usd("anthropic:claude-opus-5", 1_000_000, 1_000_000) == 30.0
     # Opus 4.8: input 5.00/1M, output 25.00/1M -> 30.00. Both are needed for the
     # effort-sweep cost/Pareto axis; an unpriced model silently yields cost=None.
     assert pricing.cost_usd("anthropic:claude-opus-4-8", 1_000_000, 1_000_000) == 30.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Anthropic's published Claude Opus 5 standard pricing so VulcanBench can estimate and enforce costs for `anthropic:claude-opus-5` runs.

## Type of change
- [x] Bug fix
- [ ] New feature / harness capability
- [ ] New seed task
- [ ] Documentation only
- [ ] Refactor / DX

## Checklist
- [x] `make ci` (lint + type + fast tests) passes locally
- [x] New code has tests
- [x] Docs updated
- [x] No secrets or large binaries committed

## Pricing

- Input: $5 per million tokens
- Output: $25 per million tokens
- Source: Anthropic's Claude Opus 5 launch and model documentation

## Verification

- Pricing and CLI tests: 42 passed
- Full suite: 493 passed, 2 deselected
- Coverage: 83.18%

## Release tweet

```text
VulcanBench v0.7.1 adds Claude Opus 5 pricing.

• anthropic:claude-opus-5
• $5/M input, $25/M output
• Cost estimates and per-run/suite caps now work for Opus 5

https://github.com/morganlinton/VulcanBench
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61b22275-316b-452a-8ca1-5d535f0c2157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61b22275-316b-452a-8ca1-5d535f0c2157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

