### PR TITLE
Land Report 10 harness fixes: effort-scaled output ceiling, truncation raise, new budgets, Opus 5 pricing

### DIFF
--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -35,11 +35,16 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from pydantic import BaseModel, Field
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 
 class ProviderError(RuntimeError):
     """Raised when a provider cannot produce a response."""
+
+
+class NonRetryableProviderError(ProviderError):
+    """A ProviderError that must fail fast: retrying only re-bills the failure
+    (e.g. a response truncated at the output ceiling)."""
 
 
 class ToolInvocation(BaseModel):
@@ -133,11 +138,26 @@ def _http_timeout(timeout_s: float | None) -> float:
 
 
 _RETRY = retry(
-    retry=retry_if_exception_type(ProviderError),
+    retry=retry_if_exception(
+        lambda e: isinstance(e, ProviderError) and not isinstance(e, NonRetryableProviderError)
+    ),
     wait=wait_exponential(multiplier=1, min=1, max=20),
     stop=stop_after_attempt(4),
     reraise=True,
 )
+
+# Anthropic output ceiling by requested effort. Thinking bills against
+# ``max_tokens`` on always-on-thinking models (Fable 5) and adaptive models
+# (Sonnet 5), so the ceiling must scale with effort — the old fixed 16K cap
+# truncated thinking-heavy steps to empty responses that were then scored as
+# wrong answers (see Report No. 10's harness note).
+_ANTHROPIC_MAX_TOKENS: dict[str, int] = {
+    "low": 32_000,
+    "medium": 64_000,
+    "high": 128_000,
+    "xhigh": 128_000,
+}
+_ANTHROPIC_MAX_TOKENS_DEFAULT = 32_000
 
 
 class OpenAIProvider(LLMProvider):
@@ -300,12 +320,10 @@ class AnthropicProvider(LLMProvider):
         base = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com").rstrip("/")
         system, converted = _to_anthropic_messages(messages)
         system_field, converted = _with_prompt_caching(system, converted)
+        max_tokens = _ANTHROPIC_MAX_TOKENS.get(effort or "", _ANTHROPIC_MAX_TOKENS_DEFAULT)
         payload: dict[str, Any] = {
             "model": self.model,
-            # Thinking counts toward max_tokens on always-on-thinking models
-            # (Fable 5) and adaptive-by-default models (Sonnet 5); 4096 could
-            # truncate a thinking-heavy step to an empty response.
-            "max_tokens": 16000,
+            "max_tokens": max_tokens,
             "messages": converted,
         }
         if effort is not None:
@@ -356,6 +374,14 @@ class AnthropicProvider(LLMProvider):
                         arguments=block.get("input", {}) or {},
                     )
                 )
+        if body.get("stop_reason") == "max_tokens" and not tool_calls:
+            # Thinking consumed the whole output budget: the step carries no
+            # action, and silently returning it would score the run as a wrong
+            # answer instead of a harness-visible failure.
+            raise NonRetryableProviderError(
+                f"response truncated at max_tokens={max_tokens} with no tool call"
+                " (stop_reason=max_tokens)"
+            )
         usage = body.get("usage", {})
         # With prompt caching, ``input_tokens`` is the UNCACHED remainder; cache reads
         # bill ~0.1x and cache writes ~1.25x (separate usage fields). Fold them into an

--- a/harness/pricing.py
+++ b/harness/pricing.py
@@ -38,6 +38,7 @@ PRICES: dict[str, dict[str, float]] = {
     "openai:o3": {"input": 2.00, "output": 8.00},
     "openai:o4-mini": {"input": 1.10, "output": 4.40},
     "anthropic:claude-fable-5": {"input": 10.00, "output": 50.00},
+    "anthropic:claude-opus-5": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-8": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-7": {"input": 5.00, "output": 25.00},
     "anthropic:claude-opus-4-6": {"input": 5.00, "output": 25.00},

--- a/harness/task_metadata.py
+++ b/harness/task_metadata.py
@@ -24,8 +24,11 @@ SCALE_DEFAULTS: dict[str, dict[str, int | float]] = {
     "micro": {"suggested_max_steps": 50, "suggested_timeout_s": 300},
     "small": {"suggested_max_steps": 60, "suggested_timeout_s": 600},
     "medium": {"suggested_max_steps": 100, "suggested_timeout_s": 1200},
-    "large": {"suggested_max_steps": 150, "suggested_timeout_s": 1800},
-    "xlarge": {"suggested_max_steps": 200, "suggested_timeout_s": 1800},
+    # large/xlarge raised from 1800s in July 2026 (Report No. 10 ran under
+    # these values): always-on-thinking models were hitting the 30-minute wall
+    # mid-work. Reports 07/08 predate the change and ran at 1800s.
+    "large": {"suggested_max_steps": 150, "suggested_timeout_s": 2700},
+    "xlarge": {"suggested_max_steps": 200, "suggested_timeout_s": 3600},
 }
 MAX_SNAPSHOT_BYTES = 100 * 1024 * 1024
 LIST_FILES_CAP = 500

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -68,6 +68,9 @@ def test_anthropic_frontier_models_priced() -> None:
     # Opus 4.8: input 5.00/1M, output 25.00/1M -> 30.00. Both are needed for the
     # effort-sweep cost/Pareto axis; an unpriced model silently yields cost=None.
     assert pricing.cost_usd("anthropic:claude-opus-4-8", 1_000_000, 1_000_000) == 30.0
+    # Opus 5: input 5.00/1M, output 25.00/1M -> 30.00 (Report No. 10 pricing).
+    assert pricing.is_priced("anthropic:claude-opus-5")
+    assert pricing.cost_usd("anthropic:claude-opus-5", 1_000_000, 1_000_000) == 30.0
     # Fable 5: input 10.00/1M, output 50.00/1M -> 60.00.
     assert pricing.is_priced("anthropic:claude-fable-5")
     assert pricing.cost_usd("anthropic:claude-fable-5", 1_000_000, 1_000_000) == 60.0

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -415,6 +415,64 @@ def test_zai_ignores_effort(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp.content == "ok"
 
 
+def test_anthropic_max_tokens_scales_with_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
+    seen: dict[str, object] = {}
+
+    def fake_post(url, headers, payload, timeout=120):  # type: ignore[no-untyped-def]
+        seen["max_tokens"] = payload["max_tokens"]
+        return {"content": [{"type": "text", "text": "ok"}], "usage": {}}
+
+    monkeypatch.setattr(P, "_http_post_json", fake_post)
+    AnthropicProvider("claude-opus-5").complete([{"role": "user", "content": "hi"}], [])
+    assert seen["max_tokens"] == 32_000
+    AnthropicProvider("claude-opus-5").complete(
+        [{"role": "user", "content": "hi"}], [], effort="xhigh"
+    )
+    assert seen["max_tokens"] == 128_000
+    AnthropicProvider("claude-opus-5").complete(
+        [{"role": "user", "content": "hi"}], [], effort="medium"
+    )
+    assert seen["max_tokens"] == 64_000
+
+
+def test_anthropic_truncated_response_raises_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A step whose whole output budget went to thinking carries no action;
+    # it must raise (harness-visible) and must NOT be retried (re-bills the
+    # same failure at up to 128K output tokens per attempt).
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
+    calls = {"n": 0}
+
+    def fake_post(url, headers, payload, timeout=120):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        return {"content": [], "stop_reason": "max_tokens", "usage": {}}
+
+    monkeypatch.setattr(P, "_http_post_json", fake_post)
+    with pytest.raises(P.NonRetryableProviderError, match="max_tokens"):
+        AnthropicProvider("claude-fable-5").complete([{"role": "user", "content": "hi"}], [])
+    assert calls["n"] == 1
+
+
+def test_anthropic_truncated_with_tool_call_still_returns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # If a complete tool_use block survived the cutoff the step is actionable.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
+
+    def fake_post(url, headers, payload, timeout=120):  # type: ignore[no-untyped-def]
+        return {
+            "content": [{"type": "tool_use", "id": "t1", "name": "run_tests", "input": {}}],
+            "stop_reason": "max_tokens",
+            "usage": {},
+        }
+
+    monkeypatch.setattr(P, "_http_post_json", fake_post)
+    resp = AnthropicProvider("claude-fable-5").complete([{"role": "user", "content": "hi"}], [])
+    assert resp.tool_calls[0].name == "run_tests"
+
+
 def test_kimi_complete_omits_temperature(monkeypatch: pytest.MonkeyPatch) -> None:
     # kimi-k3 rejects sampling params; the payload must not carry temperature.
     monkeypatch.setenv("MOONSHOT_API_KEY", "kimi-test")


### PR DESCRIPTION
## Summary
- Anthropic `max_tokens` scales with effort (32K/64K/128K); fixed 16K cap removed
- Truncated no-tool-call responses raise `NonRetryableProviderError` (no retry) instead of silently scoring as wrong answers
- `SCALE_DEFAULTS` large/xlarge -> 2700s/3600s (the budgets Report No. 10 ran under)
- `anthropic:claude-opus-5` priced at $5/$25 per M

These bring the public harness in line with what Report No. 10 describes ("we fixed the harness") — the fix previously existed only in the workspace that produced the report.

## Audit context
A scan of all 518 local v3-era traces found exactly 2 runs with the 16K-cap signature (completion_tokens == 16000, empty content, no tool calls, run ends): Fable 5 medium on networkx-leiden-communities and pennylane-trotter-fragmented — the former is a published Report 07 failure and is being re-run under this fix.

## Test plan
- 498 tests pass, incl. new: max_tokens effort scaling, truncation raises without retry, truncated-with-tool-call still returns, Opus 5 pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)