### PR TITLE
Drop duplicate load_dotenv call in CLI

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -35,14 +35,10 @@ from harness.tasks import list_task_ids
 from harness.validate import main as validate_main
 from harness.voice.cli import voice_app
 
-# Provider keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, ...) are read straight from
-# os.environ, so load the nearest .env first. Real environment variables win:
-# load_dotenv does not override anything already set in the shell.
+# Provider keys and harness settings are read straight from os.environ, so
+# load the nearest .env first (see .env.example). Real environment variables
+# win: load_dotenv does not override anything already set in the shell.
 load_dotenv()
-
-# Load provider keys and harness settings from ./.env (see .env.example).
-# override=False: variables already exported in the shell win over the file.
-load_dotenv(override=False)
 
 app = typer.Typer(
     name="vulcanbench",


### PR DESCRIPTION
## Summary

PR #31 and the voice eval suite both added a `load_dotenv` call to `harness/cli.py`, so after merging both, the CLI called it twice back-to-back. Keep a single call with a merged comment — the default `override=False` already means shell-exported variables win over `.env`.

## Test plan

- [x] ruff clean
- [ ] `tests/test_cli.py` cannot run locally on Python 3.14 due to a pre-existing failure on `main`: `harness/voice/audio.py` imports `audioop`, which was removed from the stdlib in Python 3.13, breaking the CLI import chain (and `vulcanbench --version`) entirely. Unrelated to this change; needs its own fix (e.g. the `audioop-lts` backport or a lazy import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)