### PR TITLE
Fix DeepSeek effort mapping to the real low/high/max enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **DeepSeek provider** (`deepseek:<model>`): DeepSeek OpenAI-compatible Chat Completions
   API. Needs `DEEPSEEK_API_KEY`; base URL defaults to `https://api.deepseek.com`
-  (override with `DEEPSEEK_BASE_URL`). `--effort low/medium/high` maps to the API's
-  `reasoning_effort` field; `extra-high` is recorded as metadata only. Built-in pricing
-  covers `deepseek-v4-flash` and `deepseek-v4-pro` (public-beta list rates; the announced
-  peak/off-peak 2x policy is not yet in effect and is not modeled).
+  (override with `DEEPSEEK_BASE_URL`). `--effort low/high` maps to the API's
+  `reasoning_effort` field and `extra-high` maps to its `max`; `medium` is recorded as
+  metadata only, because DeepSeek's documented enum is low/high/max and the API silently
+  coerces `medium` to `high` — sending it would stamp false effort metadata on runs.
+  Built-in pricing covers `deepseek-v4-flash` and `deepseek-v4-pro` (public-beta list
+  rates; the announced peak/off-peak 2x policy is not yet in effect and is not modeled).
 - **CLI loads `./.env`**: the `vulcanbench` CLI now calls `load_dotenv(override=False)` at
   import, so provider keys and harness settings in `.env` (see `.env.example`) are picked up
   without exporting them; variables already set in the shell take precedence.

--- a/README.md
+++ b/README.md
@@ -160,8 +160,10 @@ Specify a model as `provider:model`:
   international endpoint; set `DASHSCOPE_BASE_URL` for China or another region.
   Reasoning effort is not supported; `--effort` is recorded as metadata only.
 - `deepseek:<model>` — DeepSeek OpenAI-compatible Chat Completions API. Needs
-  `DEEPSEEK_API_KEY`. `low`/`medium`/`high` map to DeepSeek's
-  `reasoning_effort` field; `extra-high` is recorded as metadata only.
+  `DEEPSEEK_API_KEY`. `low`/`high` map to DeepSeek's `reasoning_effort` field
+  and `extra-high` maps to its `max`; `medium` is recorded as metadata only
+  (DeepSeek's enum is low/high/max — it silently coerces `medium` to `high`,
+  so the harness never sends it).
 
 `--effort` accepts `low`, `medium`, `high`, or `extra-high`. OpenAI runs map it
 to the Responses API `reasoning.effort` field; Anthropic runs map it to the

--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -678,9 +678,11 @@ class DeepSeekProvider(LLMProvider):
     """DeepSeek OpenAI-compatible Chat Completions API.
 
     Uses ``/chat/completions`` on ``https://api.deepseek.com`` (override with
-    ``DEEPSEEK_BASE_URL``). ``low``/``medium``/``high`` effort maps to the
-    API's ``reasoning_effort`` field; ``extra-high`` is recorded as metadata
-    only (DeepSeek exposes no level above ``high`` today).
+    ``DEEPSEEK_BASE_URL``). ``low``/``high`` effort maps straight to the API's
+    ``reasoning_effort`` field and ``extra-high`` maps to ``max`` (DeepSeek's
+    documented enum is low/high/max, default high). ``medium`` is recorded as
+    metadata only — DeepSeek has no medium level and silently coerces it to
+    ``high``, so the harness never sends it.
     """
 
     @property

--- a/harness/effort.py
+++ b/harness/effort.py
@@ -32,12 +32,16 @@ _KIMI_EFFORT_VALUES = {
     "extra-high": "max",
 }
 
-# DeepSeek `reasoning_effort` (V4 API). Accepts low/medium/high; there is no
-# level above "high" today, so extra-high falls back to recorded-but-not-sent.
+# DeepSeek `reasoning_effort` (V4 API). The documented enum is low/high/max
+# (default high). "medium" does not exist — the API silently coerces it to
+# "high" — so medium is absent from this map and falls back to
+# recorded-but-not-sent (the run then executes at the default, which is also
+# high; the metadata honestly says supported=False rather than pretending a
+# medium level ran).
 _DEEPSEEK_EFFORT_VALUES = {
     "low": "low",
-    "medium": "medium",
     "high": "high",
+    "extra-high": "max",
 }
 
 

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -56,23 +56,26 @@ def test_qwen_effort_is_noop_metadata() -> None:
     }
 
 
-def test_deepseek_effort_maps_low_medium_high() -> None:
-    cfg = effort_config("deepseek", "high")
-    assert cfg is not None
-    assert cfg.as_summary() == {
-        "requested": "high",
-        "provider": "deepseek",
-        "provider_value": "high",
-        "supported": True,
-    }
+def test_deepseek_effort_maps_low_high_and_max() -> None:
+    for requested, sent in (("low", "low"), ("high", "high"), ("extra-high", "max")):
+        cfg = effort_config("deepseek", requested)
+        assert cfg is not None
+        assert cfg.as_summary() == {
+            "requested": requested,
+            "provider": "deepseek",
+            "provider_value": sent,
+            "supported": True,
+        }
 
 
-def test_deepseek_extra_high_is_noop_metadata() -> None:
-    # DeepSeek's reasoning_effort has no level above "high" today.
-    cfg = effort_config("deepseek", "extra-high")
+def test_deepseek_medium_is_noop_metadata() -> None:
+    # DeepSeek's enum is low/high/max: "medium" does not exist and the API
+    # silently coerces it to "high", so the harness must not send it (the run
+    # then executes at the default and the metadata says supported=False).
+    cfg = effort_config("deepseek", "medium")
     assert cfg is not None
     assert cfg.as_summary() == {
-        "requested": "extra-high",
+        "requested": "medium",
         "provider": "deepseek",
         "provider_value": None,
         "supported": False,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -703,7 +703,7 @@ def test_deepseek_complete_requires_key(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_deepseek_sends_reasoning_effort_when_given(monkeypatch: pytest.MonkeyPatch) -> None:
     # The loop only passes effort when effort_config says supported, and it
-    # passes the provider value ("low"/"medium"/"high"); sent verbatim.
+    # passes the provider value ("low"/"high"/"max"); sent verbatim.
     monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test")
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

DeepSeek's documented `reasoning_effort` enum is **low / high / max** (default `high`) — there is no `medium`. Worse, the API doesn't reject `medium`: per their API reference, *"For compatibility, `medium` and `xhigh` are mapped to `high`."* The provider added in #31 assumed an OpenAI-style low/medium/high enum, so a `--effort medium` DeepSeek run silently executed at **high** while its run metadata claimed `supported: true, provider_value: medium`.

Fix, per the docs:
- `low` → `low`, `high` → `high` (verbatim)
- `extra-high` → `max` (previously recorded-only; `max` is DeepSeek's real top level)
- `medium` → recorded-but-not-sent (`supported: false`) — the run executes at the API default (also `high`), and the metadata now says so honestly instead of pretending a distinct medium level ran

Impact on existing data: any DeepSeek suite column recorded at `medium` is actually a duplicate `high` run and should not be compared as a distinct effort level.

## Test plan

- [x] `test_deepseek_effort_maps_low_high_and_max` — all three real levels map with `supported: true`
- [x] `test_deepseek_medium_is_noop_metadata` — medium is never sent
- [x] Full effort/provider test files pass; ruff + mypy clean
- [x] Live validation: full suite v3 run at `--effort extra-high` (sends `max`) completed — pass@1 0.913 (21/23), $1.39, confirming `max` is accepted and distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
