### PR TITLE
Wire Qwen reasoning_effort (low/medium/xhigh enum, Qwen3.8+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Qwen reasoning effort** (`qwen:<model>`, Qwen3.8+): `--effort low/medium` maps to
+  DashScope's `reasoning_effort` and `extra-high` maps to its `xhigh`; `high` is recorded
+  as metadata only because Qwen's documented enum is low/medium/xhigh (no `high`) with
+  `xhigh` as the default — an unset request already runs at xhigh. Built-in pricing adds
+  `qwen3.8-max` ($2/$6 per 1M, flat across the 1M context).
+
 ## [0.8.0] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ Specify a model as `provider:model`:
 - `qwen:<model>` — Alibaba Cloud DashScope (Qwen) OpenAI-compatible Chat
   Completions API. Needs `DASHSCOPE_API_KEY`. Default base URL is the
   international endpoint; set `DASHSCOPE_BASE_URL` for China or another region.
-  Reasoning effort is not supported; `--effort` is recorded as metadata only.
+  `low`/`medium` map to Qwen's `reasoning_effort` and `extra-high` maps to its
+  `xhigh` (Qwen3.8+; the documented enum is low/medium/xhigh, default xhigh).
+  `high` is recorded as metadata only — Qwen has no such level, and an unset
+  request runs at the xhigh default. Pre-3.8 models may ignore the field.
 - `deepseek:<model>` — DeepSeek OpenAI-compatible Chat Completions API. Needs
   `DEEPSEEK_API_KEY`. `low`/`high` map to DeepSeek's `reasoning_effort` field
   and `extra-high` maps to its `max`; `medium` is recorded as metadata only

--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -626,10 +626,11 @@ class QwenProvider(LLMProvider):
     Uses ``/compatible-mode/v1/chat/completions``. Default base URL is the
     international endpoint; set ``DASHSCOPE_BASE_URL`` for China
     (``https://dashscope.aliyuncs.com/compatible-mode/v1``) or another region.
-    Reasoning effort is not supported on this path (``reasoning_effort`` is
-    silently ignored by DashScope; Qwen's ``enable_thinking`` needs streaming
-    on some models, which this harness does not use yet) — ``--effort`` is
-    recorded as metadata only.
+    Effort maps to the API's ``reasoning_effort`` field, supported on
+    non-streaming calls since the Qwen3.8 series. The documented enum is
+    low/medium/xhigh (default xhigh) — there is no ``high``, so ``--effort
+    high`` is recorded as metadata only and the run executes at the model
+    default. Pre-3.8 models may ignore the field.
     """
 
     @property
@@ -643,11 +644,10 @@ class QwenProvider(LLMProvider):
         timeout_s: float | None = None,
         effort: str | None = None,
     ) -> LLMResponse:
-        del effort
         timeout = _http_timeout(timeout_s)
         if timeout_s is not None:
-            return self._complete_once(messages, tools, timeout)
-        return self._complete_with_retry(messages, tools, timeout)
+            return self._complete_once(messages, tools, timeout, effort)
+        return self._complete_with_retry(messages, tools, timeout, effort)
 
     @_RETRY
     def _complete_with_retry(
@@ -655,14 +655,16 @@ class QwenProvider(LLMProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         timeout: float,
+        effort: str | None,
     ) -> LLMResponse:
-        return self._complete_once(messages, tools, timeout)
+        return self._complete_once(messages, tools, timeout, effort)
 
     def _complete_once(
         self,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]],
         timeout: float,
+        effort: str | None,
     ) -> LLMResponse:
         api_key = os.environ.get("DASHSCOPE_API_KEY")
         if not api_key:
@@ -671,7 +673,15 @@ class QwenProvider(LLMProvider):
             "DASHSCOPE_BASE_URL",
             "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         ).rstrip("/")
-        return _chat_completions_complete(base, api_key, self.model, messages, tools, timeout)
+        return _chat_completions_complete(
+            base,
+            api_key,
+            self.model,
+            messages,
+            tools,
+            timeout,
+            extra_payload={"reasoning_effort": effort} if effort else None,
+        )
 
 
 class DeepSeekProvider(LLMProvider):

--- a/harness/effort.py
+++ b/harness/effort.py
@@ -44,6 +44,23 @@ _DEEPSEEK_EFFORT_VALUES = {
     "extra-high": "max",
 }
 
+# Qwen `reasoning_effort` (DashScope compatible-mode, Qwen3.8+). The documented
+# enum is low/medium/xhigh with xhigh as the DEFAULT — there is no "high", so
+# "high" is absent from this map and falls back to recorded-but-not-sent (the
+# run then executes at the model default, which is xhigh; the metadata says
+# supported=False rather than pretending a distinct high level ran).
+_QWEN_EFFORT_VALUES = {
+    "low": "low",
+    "medium": "medium",
+    "extra-high": "xhigh",
+}
+
+_PROVIDER_EFFORT_MAPS = {
+    "kimi": _KIMI_EFFORT_VALUES,
+    "deepseek": _DEEPSEEK_EFFORT_VALUES,
+    "qwen": _QWEN_EFFORT_VALUES,
+}
+
 
 class EffortNotSupportedError(ValueError):
     """Raised when a provider cannot run a requested effort level."""
@@ -107,28 +124,19 @@ def effort_config(provider: str, requested: str | None) -> EffortConfig | None:
             provider_value=_OPENAI_EFFORT_VALUES[effort],
             supported=True,
         )
-    # kimi: K3 always thinks; its reasoning_effort currently accepts only "max"
-    # (Moonshot has announced more levels — extend this map when they ship).
-    # Other levels are recorded on the run but not sent.
-    if provider_name == "kimi":
-        provider_value = _KIMI_EFFORT_VALUES.get(effort)
+    # Map-driven providers: each API's documented reasoning_effort enum lives
+    # in its map above; levels absent from a map are recorded-but-not-sent.
+    if provider_name in _PROVIDER_EFFORT_MAPS:
+        provider_value = _PROVIDER_EFFORT_MAPS[provider_name].get(effort)
         return EffortConfig(
             requested=effort,
-            provider="kimi",
-            provider_value=provider_value,
-            supported=provider_value is not None,
-        )
-    if provider_name == "deepseek":
-        provider_value = _DEEPSEEK_EFFORT_VALUES.get(effort)
-        return EffortConfig(
-            requested=effort,
-            provider="deepseek",
+            provider=provider_name,
             provider_value=provider_value,
             supported=provider_value is not None,
         )
     # claude-code: headless Claude Code has no per-request effort control;
     # the requested level is recorded on the run but not sent.
-    if provider_name in {"mock", "zai", "qwen", "claude-code"}:
+    if provider_name in {"mock", "zai", "claude-code"}:
         return EffortConfig(
             requested=effort,
             provider=provider_name,

--- a/harness/pricing.py
+++ b/harness/pricing.py
@@ -56,6 +56,7 @@ PRICES: dict[str, dict[str, float]] = {
     # DashScope international list prices (≤256K / ≤32K tier as applicable).
     # Long-context tiers and promo discounts are not modeled — override with
     # VULCANBENCH_PRICING for exact numbers.
+    "qwen:qwen3.8-max": {"input": 2.00, "output": 6.00},
     "qwen:qwen3.7-plus": {"input": 0.40, "output": 1.60},
     "qwen:qwen3.7-max": {"input": 2.50, "output": 7.50},
     "qwen:qwen3.6-flash": {"input": 0.25, "output": 1.50},

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -45,7 +45,22 @@ def test_zai_effort_is_noop_metadata() -> None:
     }
 
 
-def test_qwen_effort_is_noop_metadata() -> None:
+def test_qwen_effort_maps_low_medium_and_xhigh() -> None:
+    for requested, sent in (("low", "low"), ("medium", "medium"), ("extra-high", "xhigh")):
+        cfg = effort_config("qwen", requested)
+        assert cfg is not None
+        assert cfg.as_summary() == {
+            "requested": requested,
+            "provider": "qwen",
+            "provider_value": sent,
+            "supported": True,
+        }
+
+
+def test_qwen_high_is_noop_metadata() -> None:
+    # Qwen's enum is low/medium/xhigh with xhigh as the default: "high" does
+    # not exist, so it must never be sent (the run executes at the default and
+    # the metadata says supported=False).
     cfg = effort_config("qwen", "high")
     assert cfg is not None
     assert cfg.as_summary() == {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -628,7 +628,9 @@ def test_qwen_complete_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
         QwenProvider("qwen3.7-plus").complete([], [])
 
 
-def test_qwen_ignores_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_qwen_sends_reasoning_effort_when_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The loop only passes effort when effort_config says supported, and it
+    # passes the provider value ("low"/"medium"/"xhigh"); sent verbatim.
     monkeypatch.setenv("DASHSCOPE_API_KEY", "qwen-test")
     seen: dict[str, object] = {}
 
@@ -637,10 +639,11 @@ def test_qwen_ignores_effort(monkeypatch: pytest.MonkeyPatch) -> None:
         return {"choices": [{"message": {"content": "ok"}}], "usage": {}}
 
     monkeypatch.setattr(P, "_http_post_json", fake_post)
-    resp = QwenProvider("qwen3.7-plus").complete([], [], effort="high")
-    assert "enable_thinking" not in seen["payload"]  # type: ignore[operator]
+    QwenProvider("qwen3.8-max").complete([], [], effort="xhigh")
+    assert seen["payload"]["reasoning_effort"] == "xhigh"  # type: ignore[index]
+    QwenProvider("qwen3.8-max").complete([], [])
     assert "reasoning_effort" not in seen["payload"]  # type: ignore[operator]
-    assert resp.content == "ok"
+    assert "enable_thinking" not in seen["payload"]  # type: ignore[operator]
 
 
 def test_deepseek_complete_parses_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Qwen3.8+ supports `reasoning_effort` on DashScope's OpenAI-compatible **non-streaming** path (the pre-3.8 limitation is gone), so the `qwen:` provider now sends it instead of discarding effort. Verified against the official docs (docs.qwencloud.com → text-generation → thinking), the enum is **low / medium / xhigh with `xhigh` as the default** — there is no `high`:

- `low` → `low`, `medium` → `medium`, `extra-high` → `xhigh` (all `supported: true`)
- `high` → recorded-but-not-sent (`supported: false`) — the run executes at the model default (xhigh) and the metadata says so honestly, applying the lesson from the DeepSeek medium-coercion fix (#33)
- `effort_config`'s per-provider branches (kimi/deepseek/qwen) collapsed into a table-driven lookup
- Built-in pricing: `qwen:qwen3.8-max` at $2/$6 per 1M (flat across its 1M context)
- Pre-3.8 Qwen models may ignore the field; documented in the provider docstring and README

## Test plan

- [x] `test_qwen_effort_maps_low_medium_and_xhigh` + `test_qwen_high_is_noop_metadata`
- [x] `test_qwen_sends_reasoning_effort_when_given` (sent verbatim when resolved; omitted otherwise)
- [x] ruff + format + mypy clean
- [x] Live: hello-world on `qwen3.8-max` at `--effort low` — functional=1.0, \$0.0086, run metadata records `provider_value: low, supported: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)