### PR TITLE
Fix Python 3.13+ startup, node-ts sandbox target, cargo-free test; add 3.14 CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,31 @@ jobs:
       - name: Validate tasks (gold patches solve, fail-to-pass real, deterministic)
         run: python scripts/validate_tasks.py tasks/v1
 
+  python-3-14-smoke:
+    # Deliberately light: the main job pins 3.12 and carries every toolchain;
+    # this one only proves the pure-Python layer installs and runs on the
+    # newest CPython. It exists because audioop left the stdlib in 3.13 and
+    # took every `vulcanbench` command down with it on 3.13+ until the
+    # audioop-lts marker dep landed -- a class of bug 3.12-only CI can't see.
+    # No LFS, no Go/Node/Rust/Java, no ruff/mypy (enforced on 3.12 already),
+    # no coverage gate (same number as the main job), no task validation.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: 'pip'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: CLI imports and starts
+        run: vulcanbench --version && vulcanbench --help
+      - name: Pytest (fast, no Docker, no coverage gate)
+        run: pytest -m "not slow and not docker" --no-cov -p no:cacheprovider
+
   dashboard-lint-build:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   probes. The harness brings the stack up under a unique per-run project
   before the agent's clock starts, resolves ephemeral published ports into a
   gitignored `.vb_services.json` in the workspace, and always tears down with
-  `down -v` — in `vulcanbench run` and in task validation (fresh stack per
+  `down -v`, in `vulcanbench run` and in task validation (fresh stack per
   gold/base/determinism run). Validation rejects the isolation footguns
   (`container_name`, fixed host ports). Environment tasks require
   `--sandbox local`; the walking-skeleton template is
@@ -198,6 +198,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Python 3.13+ installs are usable again.** `audioop` left the stdlib in 3.13 (PEP 594),
+  and `harness/voice/audio.py` imports it at module scope, so on 3.13/3.14 *every*
+  `vulcanbench` command died at import, not just the voice suite. The `audioop-lts`
+  backport is now a dependency behind a `python_version >= '3.13'` marker.
+- **`make sandbox-image-all` builds the Node/TypeScript image.** It was missing
+  `vulcanbench/sandbox:node-ts`, so `make validate-cyber` (and Docker validation of the
+  JS/TS tasks in v3/v4) failed with a misleading "pull access denied" as Docker tried to
+  fetch the absent local tag from Docker Hub. Added a `sandbox-image-node-ts` target.
+- **CI runs a Python 3.14 smoke job** (`python-3-14-smoke`): install with `[test]` only,
+  `vulcanbench --version`, fast pytest. Light on purpose, no toolchains, no lint/mypy,
+  no coverage gate, it exists to catch exactly the stdlib-drift class above, which a
+  3.12-only job cannot see. `pytest-asyncio` moved from the `dev` extra to `test`, where
+  the other pytest plugins live, so `[test]` alone satisfies the `asyncio_mode` config.
+- **`test_security_rust_budget_exhausted` no longer depends on a local cargo install.**
+  `security._rust` checks for cargo before it checks the budget, so on a machine without
+  the Rust toolchain the test asserted the wrong branch and failed; it now mocks cargo
+  as present.
 - **Host-run CLI agents can no longer pip-install into the system Python.**
   `_subscription_env()` now sets `PIP_REQUIRE_VIRTUALENV=1` and
   `PYTHONNOUSERSITE=1` for every subscription CLI subprocess (claude-code,

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VULCANBENCH := $(VENV_BIN)/vulcanbench
 # the venv. This makes `make ci` behave the same from any shell.
 export PATH := $(abspath $(VENV_BIN)):$(PATH)
 
-.PHONY: help setup clean install dev test lint no-emdash typecheck fmt ci docker-up docker-down validate-tasks sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-all
+.PHONY: help setup clean install dev test lint no-emdash typecheck fmt ci docker-up docker-down validate-tasks sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-node-ts sandbox-image-go-1.26 sandbox-image-all
 .DEFAULT_GOAL := help
 
 help: ## Show this help
@@ -74,11 +74,15 @@ sandbox-image-rust-2024: sandbox-image ## Build Rust sandbox image on a newer to
 	docker build -t vulcanbench/sandbox:rust-2024 -f sandbox/Dockerfile.rust-2024 .
 	@echo "✅ Built vulcanbench/sandbox:rust-2024, for crates whose MSRV exceeds :rust"
 
+sandbox-image-node-ts: sandbox-image ## Build Node/TypeScript sandbox image (extends base)
+	docker build -t vulcanbench/sandbox:node-ts -f sandbox/Dockerfile.node-ts .
+	@echo "✅ Built vulcanbench/sandbox:node-ts, auto-selected for JS/TS tasks"
+
 sandbox-image-go-1.26: sandbox-image ## Build Go 1.26 sandbox image (for repos whose go.mod needs go >= 1.24)
 	docker build -t vulcanbench/sandbox:go-1.26 -f sandbox/Dockerfile.go-1.26 .
 	@echo "✅ Built vulcanbench/sandbox:go-1.26, for Go modules newer than the base image's 1.23"
 
-sandbox-image-all: sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-go-1.26 ## Build base + Rust + Go-1.26 sandbox images
+sandbox-image-all: sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-node-ts sandbox-image-go-1.26 ## Build base + Rust + Node/TS + Go-1.26 sandbox images
 
 docker-up: ## Start local Postgres (see docker-compose.prod.yml for full stack)
 	docker compose up -d db

--- a/docs/TASK_CONTRIBUTION.md
+++ b/docs/TASK_CONTRIBUTION.md
@@ -181,9 +181,9 @@ compose file and declares:
 
 Rules the validator enforces:
 
-- publish ports **ephemerally** (`ports: ["6379"]`) — never `"6379:6379"`;
+- publish ports **ephemerally** (`ports: ["6379"]`), never `"6379:6379"`;
   the harness resolves the real host ports per run,
-- no `container_name:` — per-run compose projects must not collide,
+- no `container_name:`, per-run compose projects must not collide,
 - every `ready` probe needs `service` and `cmd` (run via `docker compose
   exec` until it exits 0).
 

--- a/harness/voice/audio.py
+++ b/harness/voice/audio.py
@@ -15,10 +15,10 @@ deterministically per item by hashing the item id) into the clean render at
 a fixed **10 dB SNR**, computed from RMS over the speech segment. The clip
 set and SNR are documented in ``tasks/voice-v1/noise/README.md``.
 
-Everything here is stdlib-only (``wave`` + ``audioop``). ``audioop`` is
-deprecated upstream but present on Python 3.12, which this repo pins; if the
-project moves to 3.13 these helpers need a replacement (tracked in the
-module docstring on purpose).
+Everything here is ``wave`` + ``audioop``. ``audioop`` is stdlib on Python
+3.12 but was removed in 3.13 (PEP 594); on 3.13+ the identical C code comes
+from the ``audioop-lts`` backport, which ``pyproject.toml`` pulls in behind a
+``python_version >= '3.13'`` marker. The import below is the same either way.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
   "docker>=7.1.0",
   "tenacity>=8.4.0",
   "websockets>=12.0",   # Voice Eval Suite: OpenAI Realtime + Gemini Live transports
+  # audioop left the stdlib in 3.13 (PEP 594); harness/voice/audio.py imports it
+  # at module scope, and harness/cli.py imports the voice CLI, so without this
+  # EVERY vulcanbench command fails to start on 3.13+. audioop-lts is the
+  # maintained extraction of the same C code.
+  "audioop-lts>=0.2.1; python_version >= '3.13'",
   "jsonschema>=4.22.0",
   "python-dotenv>=1.0.1",
   # Evaluator: quality (lint + complexity) and security analysis for Python.
@@ -44,7 +49,6 @@ dev = [
   "mypy>=1.11.0",
   "pytest>=8.2.0",
   "pytest-cov>=5.0.0",
-  "pytest-asyncio>=0.23.0",
   "black>=24.4.0",
   "pre-commit>=3.7.0",
   "types-pyyaml>=6.0.12",
@@ -54,6 +58,7 @@ test = [
   "pytest>=8.2.0",
   "pytest-cov>=5.0.0",
   "pytest-mock>=3.14.0",
+  "pytest-asyncio>=0.23.0",  # pyproject sets asyncio_mode; plugin must be present or pytest warns
   "httpx>=0.27.0",     # Starlette TestClient
   "fastapi>=0.115.0",  # exercise the API in CI
   "sqlmodel>=0.0.21",  # exercise the DB store (SQLite) in CI
@@ -142,8 +147,8 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-ra -q --strict-markers --cov=harness --cov-report=term-missing:skip-covered --cov-fail-under=80"
 filterwarnings = [
-  # audioop is deprecated upstream but present on 3.12 (this repo's pin); the
-  # voice suite uses it deliberately, see harness/voice/audio.py docstring.
+  # audioop is deprecated on 3.12 and removed in 3.13 (audioop-lts backfills it
+  # there); the voice suite uses it deliberately; see harness/voice/audio.py.
   "ignore:'audioop' is deprecated:DeprecationWarning",
 ]
 markers = [

--- a/tests/test_rust_analyzers.py
+++ b/tests/test_rust_analyzers.py
@@ -179,7 +179,10 @@ def test_unsafe_delta_penalty() -> None:
     assert final == 0.9
 
 
-def test_security_rust_budget_exhausted(tmp_path: Path) -> None:
+def test_security_rust_budget_exhausted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # _rust checks for cargo before it checks the budget, so pretend cargo is
+    # installed, otherwise this asserts the wrong branch on machines without it.
+    monkeypatch.setattr(security.shutil, "which", lambda name: "/usr/bin/cargo")
     (tmp_path / "main.rs").write_text("fn main() {}\n")
     (tmp_path / "Cargo.lock").write_text("# lockfile\n")
     result = security._rust(tmp_path, ["main.rs"], remaining_s=lambda: -1.0)


### PR DESCRIPTION
## Summary

Found while smoke-testing VulcanBench on a fresh machine (Python 3.14, Docker 29.7). Four fixes, all small:

- **Python 3.13+ installs were dead on arrival.** `audioop` left the stdlib in 3.13 (PEP 594); `harness/voice/audio.py` imports it at module scope and `harness/cli.py` imports the voice CLI, so *every* `vulcanbench` command failed at import on 3.13/3.14 — despite `requires-python = ">=3.12"` and 3.13/3.14 classifiers. Added `audioop-lts>=0.2.1; python_version >= '3.13'` (the maintained extraction of the same C code) and refreshed the stale "this repo pins 3.12" comments.
- **`make sandbox-image-all` didn't build `vulcanbench/sandbox:node-ts`**, so `make validate-cyber` (and Docker validation of the v3/v4 hono/zod tasks) failed with a misleading "pull access denied" as Docker tried to fetch the absent local tag from Docker Hub. Added `sandbox-image-node-ts` and wired it in.
- **`test_security_rust_budget_exhausted` needed a local cargo.** `security._rust` checks for cargo before the budget, so without a Rust toolchain it hit the wrong branch and failed. Now mocks cargo as present, matching the rest of the file — the budget branch is genuinely exercised.
- **New CI job `python-3-14-smoke`**: `[test]`-only install → `vulcanbench --version` → fast pytest. Deliberately light (no toolchains, lint, mypy, coverage gate, or task validation) so it runs in ~2 min in parallel; it exists to catch exactly the stdlib-drift class above, which the 3.12-only job can't see. `pytest-asyncio` moved from the `dev` extra to `test` so a `[test]`-only install satisfies the `asyncio_mode` config without a warning.

## Test plan

- [x] `make ci` — lint + mypy + fast tests: 575 passed, 1 skipped (cargo integration), 84.78% coverage
- [x] Smoke job steps replayed locally in a clean 3.14 venv with `[test]` only: CLI starts, 575 passed, no `asyncio_mode` warning
- [x] Clean `pip install -e .` on 3.14 pulls `audioop-lts` automatically; `vulcanbench --version` works with no manual step
- [x] `make sandbox-image-node-ts` builds after `docker rmi`; `validate-task --sandbox docker` PASS on `oss-werkzeug-etag-strict-parse` (py) and `oss-zod-jsonschema-proto-pollution` (ts)
- [x] CI: confirm the new `python-3-14-smoke` job appears and goes green on this PR — all 4 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)