### PR TITLE
memory: record Mac migration + shipped PRs #48/#49

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,5 +1,6 @@
 # Memory index
 
-- [VulcanCyber build toolchain](vulcancyber-build-toolchain.md) — gh/venv/Docker/network prereqs for building & validating tasks on this Win11 box
+- [Mac migration & shipped work 2026-08-22](mac-migration-2026-08-22.md) — dev now on macOS arm64 (user-level toolchain); vendor defect verified + regression tests (PR #48); main CI format fix (PR #49)
+- [VulcanCyber build toolchain](vulcancyber-build-toolchain.md) — gh/venv/Docker/network prereqs for building & validating tasks on the old Win11 box (superseded by the Mac note)
 - [VulcanCyber hard-tail plan](vulcancyber-hard-tail-plan.md) — DOMPurify #1560 ADMITTED (PR #45, suite=17); osv-scanner rejected; mining/build lessons
-- [VulcanCyber suite health](vulcancyber-suite-health.md) — 2026-08-16 Docker re-validation: 17/17 sound, but Go tasks' vendor/ is gitignored (clean-clone defect) + Windows CRLF fix
+- [VulcanCyber suite health](vulcancyber-suite-health.md) — 2026-08-16 Docker re-validation: 17/17 sound; Go vendor defect RESOLVED 2026-08-22 (verified in PR #48); Windows CRLF fix

--- a/memory/mac-migration-2026-08-22.md
+++ b/memory/mac-migration-2026-08-22.md
@@ -1,0 +1,15 @@
+---
+name: mac-migration-2026-08-22
+description: Dev moved from the Win11 box to a Mac (arm64) on 2026-08-22 — environment rebuilt, vendor-defect verification + CI format fix shipped (PRs #48/#49)
+metadata:
+  type: project
+---
+
+Development moved off the Win11 box to a macOS arm64 machine on 2026-08-22. What happened and what shipped:
+
+- **Environment rebuilt, all user-level (no Homebrew/sudo):** Python 3.12.14 via `uv`, git-lfs 3.7.1, rustup/cargo, Go 1.27.0, Node v24 LTS, and `gh` 2.98.0 in `~/.local/bin` / `~/.cargo` / `~/.local/{go,node}`, persisted via `~/.zshrc`. Docker Desktop was pre-installed; sandbox images `base`, `rust`, `rust-2024`, `go-1.26` built via `make sandbox-image-all` (per-task images left to build on demand). Verified: `make test` 576 passed; mock run in Docker sandbox scores functional=1.0. No provider API keys on this machine yet.
+- **git-lfs incident:** the repo arrived with a completely empty git index (~25k phantom staged deletions) because LFS-filtered operations had failed with git-lfs missing. Repaired with a filter-bypassed `git reset`; once git-lfs was installed the tree was fully clean — the working-tree tarballs matched their pointers exactly.
+- **PR #48 (merged, `a57af06a`):** closed out the Go `vendor/` clean-clone defect from [[vulcancyber-suite-health]]. The code fixes had already landed (45e79f03, 1cc69d45); #48 added the verification (clean `git archive` checkouts build offline with `GOPROXY=off -mod=vendor`; both tasks re-pass Docker validation gold=1.0 deterministic ×3; corpus-wide sweep found no other vendor mismatches) plus `tests/test_slice_repo_vendor.py` (12 regression tests for `_untrack_vendor_in_gitignore`).
+- **PR #49 (merged, `40c4d693`):** `main` CI had been red since the direct push `006418e6` — `scripts/mine_oss_prs.py` landed unformatted and the `ruff format --check` gate failed before mypy/pytest ran. Mechanical reformat; CI on main green again as of run 32583594580.
+
+Watch-out that caused #49: direct pushes to main skip the PR checks, and the format gate fails the whole job first — run `make lint` (or `make ci`) before any direct push.


### PR DESCRIPTION
Updates the committed `memory/` notes with what shipped on 2026-08-22:

- New `memory/mac-migration-2026-08-22.md`: dev moved to the Mac (user-level toolchain: uv Python 3.12, git-lfs, rustup, Go, Node, gh; Docker sandbox images built), the empty-index git-lfs incident and repair, PR #48 (vendor-defect verification + regression tests), PR #49 (main-CI format fix), and the make-lint-before-direct-push watch-out.
- `MEMORY.md` index refreshed: new note listed, suite-health line updated to "vendor defect RESOLVED", Win11 toolchain note marked superseded.

Docs/notes only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)