### PR TITLE
CII: TerminalBench-style task budgets + codex: CLI agent

### DIFF
--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -1,7 +1,8 @@
 """Run models inside their vendor's own agent CLI (subscription billing).
 
-``claude-code:<model>`` runs a task with Claude Code headless (``claude -p``)
-in the prepared workspace instead of the VulcanBench agent loop. The CLI edits
+``claude-code:<model>`` runs a task with Claude Code headless (``claude -p``),
+and ``codex:<model>`` runs it with OpenAI Codex headless (``codex exec``), in
+the prepared workspace instead of the VulcanBench agent loop. The CLI edits
 files directly in the workspace; everything downstream (git diff, verifier,
 evaluator, scoring) is unchanged.
 
@@ -47,7 +48,7 @@ from harness.agent.providers import (
 from harness.pricing import cost_usd
 from harness.redaction import sanitize
 
-CLI_AGENT_PROVIDERS = frozenset({"claude-code"})
+CLI_AGENT_PROVIDERS = frozenset({"claude-code", "codex"})
 
 # Claude Code's headless result text when a subscription window is exhausted
 # (e.g. "Claude AI usage limit reached|...", "5-hour limit reached ∙ resets 3am").
@@ -133,10 +134,12 @@ class CliAgentOutcome:
     num_turns: int | None = None
     cli_reported_cost_usd: float | None = None
 
+    harness: str = "claude-code"
+
     def summary(self) -> dict[str, Any]:
         """Provenance block persisted into the run summary."""
         return {
-            "harness": "claude-code",
+            "harness": self.harness,
             "billing": "subscription",
             "cost_basis": "hypothetical-api-pricing",
             "session_id": self.session_id,
@@ -426,4 +429,316 @@ class ClaudeCodeProvider(LLMProvider):
             content=text or None,
             usage=TokenUsage(prompt_tokens=p, completion_tokens=c),
             raw=body,
+        )
+
+
+# --------------------------------------------------------------------------
+# OpenAI Codex (`codex exec`)
+# --------------------------------------------------------------------------
+
+
+# Codex usage fields -> effective tokens. OpenAI bills cached input at ~0.1x;
+# `input_tokens` INCLUDES the cached portion, unlike Anthropic's split fields.
+def _fold_codex_usage(usage: dict[str, Any]) -> tuple[int, int]:
+    total_in = int(usage.get("input_tokens", 0) or 0)
+    cached = min(int(usage.get("cached_input_tokens", 0) or 0), total_in)
+    prompt = round((total_in - cached) + cached * 0.1)
+    return prompt, int(usage.get("output_tokens", 0) or 0)
+
+
+def _codex_env() -> dict[str, str]:
+    """Subprocess env forcing subscription auth.
+
+    With ``OPENAI_API_KEY`` set, Codex bills the API — which defeats the point
+    of CLI-agent mode. Strip it so the CLI uses the ChatGPT-subscription login
+    (``codex login``).
+    """
+    env = dict(os.environ)
+    env.pop("OPENAI_API_KEY", None)
+    return env
+
+
+# Codex reasoning-effort values (config key `model_reasoning_effort`).
+_CODEX_EFFORT_VALUES = {
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "extra-high": "xhigh",
+}
+
+
+def run_codex_task(  # noqa: PLR0912, PLR0915 — linear stream-parse loop
+    *,
+    workspace: Path,
+    prompt: str,
+    model: str,
+    priced_spec: str,
+    collector: _Collector,
+    stream_log_path: Path | None = None,
+    timeout_s: float | None = None,
+    network: bool = False,
+    max_run_cost: float | None = None,
+    effort: str | None = None,
+    codex_bin: str = "codex",
+) -> CliAgentOutcome:
+    """Run one task with Codex headless (``codex exec --json``) in ``workspace``.
+
+    Mirrors :func:`run_claude_code_task`: streams JSONL events into the trace,
+    enforces the wall-clock budget with a kill timer, and enforces
+    ``max_run_cost`` against the cumulative hypothetical API cost. Codex has no
+    turn cap, so the wall-clock budget is the binding limit. The CLI runs in
+    its ``workspace-write`` sandbox (writes confined to the workspace; network
+    off unless ``--network``), which matches the loop's parity defaults.
+    """
+    if timeout_s is not None and timeout_s <= 0:
+        raise ProviderError("run budget exhausted before CLI agent start")
+
+    cmd = [
+        codex_bin,
+        "exec",
+        "--json",
+        "--model",
+        model,
+        "--sandbox",
+        "workspace-write",
+        "--skip-git-repo-check",
+    ]
+    if network:
+        cmd += ["-c", "sandbox_workspace_write.network_access=true"]
+    effort_value = _CODEX_EFFORT_VALUES.get(effort or "")
+    if effort_value:
+        cmd += ["-c", f"model_reasoning_effort={effort_value}"]
+    cmd.append(prompt)
+
+    collector.record(
+        "cli_agent_start",
+        {"harness": "codex", "argv": [*cmd[:-1], "<prompt omitted>"]},
+    )
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=workspace,
+            env=_codex_env(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as e:
+        raise ProviderError(
+            f"{codex_bin!r} not found on PATH; install Codex (npm install -g "
+            "@openai/codex) and sign in with your ChatGPT subscription "
+            "(`codex login`)"
+        ) from e
+
+    stderr_chunks: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for chunk in proc.stderr:
+            stderr_chunks.append(chunk)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
+    outcome = CliAgentOutcome(harness="codex")
+    killed = {"timeout": False, "cost": False}
+
+    def _kill_on_timeout() -> None:
+        killed["timeout"] = True
+        proc.kill()
+
+    watchdog: threading.Timer | None = None
+    if timeout_s is not None:
+        watchdog = threading.Timer(timeout_s, _kill_on_timeout)
+        watchdog.daemon = True
+        watchdog.start()
+
+    prompt_total = completion_total = 0
+    turns = 0
+    error_text: str | None = None
+    stream_f = stream_log_path.open("w", encoding="utf-8") if stream_log_path else None
+    try:
+        assert proc.stdout is not None
+        for raw_line in proc.stdout:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if stream_f:
+                json.dump(sanitize(event), stream_f)
+                stream_f.write("\n")
+            etype = str(event.get("type") or "")
+            if etype == "thread.started":
+                outcome.session_id = event.get("thread_id")
+                collector.record("cli_agent_init", {"session_id": outcome.session_id})
+            elif etype in ("item.completed", "item.updated"):
+                item = event.get("item") or {}
+                itype = str(item.get("item_type") or item.get("type") or "")
+                if etype == "item.completed" and itype in ("assistant_message", "agent_message"):
+                    collector.record(
+                        "llm_response",
+                        {"content": item.get("text"), "tool_calls": [], "usage": {}},
+                    )
+                elif etype == "item.completed" and itype == "command_execution":
+                    collector.record(
+                        "tool_observation",
+                        {
+                            "tool": "run_command",
+                            "result": str(item.get("aggregated_output") or "")[:2000],
+                            "error": None if item.get("exit_code") in (0, None) else "tool error",
+                        },
+                    )
+                elif itype == "error":
+                    error_text = str(item.get("message") or item.get("text") or "")
+            elif etype == "turn.completed":
+                turns += 1
+                usage = event.get("usage") or {}
+                p, c = _fold_codex_usage(usage)
+                prompt_total += p
+                completion_total += c
+                if max_run_cost is not None:
+                    run_cost = cost_usd(priced_spec, prompt_total, completion_total)
+                    if run_cost is not None and run_cost >= max_run_cost:
+                        collector.record(
+                            "cost_cap_exceeded",
+                            {"cost_usd": run_cost, "max_run_cost": max_run_cost},
+                        )
+                        outcome.cost_capped = True
+                        killed["cost"] = True
+                        proc.kill()
+                        break
+            elif etype == "turn.failed":
+                error_text = str((event.get("error") or {}).get("message") or "turn failed")
+            elif etype == "error":
+                error_text = str(event.get("message") or "error")
+    finally:
+        if watchdog is not None:
+            watchdog.cancel()
+        if stream_f:
+            stream_f.close()
+
+    proc.wait()
+    stderr_thread.join(timeout=5)
+    outcome.timed_out = killed["timeout"]
+    outcome.prompt_tokens = prompt_total
+    outcome.completion_tokens = completion_total
+    outcome.num_turns = turns or None
+
+    if killed["timeout"] or killed["cost"]:
+        # Partial work still counts; the caller diffs and verifies it.
+        return outcome
+
+    if error_text and _LIMIT_PATTERN.search(error_text):
+        raise ProviderError(
+            "codex subscription limit hit — rerun after the window resets "
+            f"(use --only-missing to resume): {error_text[:300]}"
+        )
+    if proc.returncode != 0:
+        tail = (error_text or "".join(stderr_chunks)[-500:]).strip()
+        if tail and _LIMIT_PATTERN.search(tail):
+            raise ProviderError(
+                "codex subscription limit hit — rerun after the window resets "
+                f"(use --only-missing to resume): {tail[:300]}"
+            )
+        raise ProviderError(f"codex exited with {proc.returncode}: {tail[:300] or 'no stderr'}")
+    if error_text:
+        raise ProviderError(f"codex run failed: {error_text[:300]}")
+
+    outcome.finished = True
+    outcome.subtype = "success"
+    collector.record("cli_agent_result", outcome.summary())
+    return outcome
+
+
+class CodexProvider(LLMProvider):
+    """Single-shot completions through Codex headless.
+
+    Used for judge/grader calls when the run model is a ``codex:`` spec, so
+    evaluation also bills the subscription. Runs in the read-only sandbox;
+    tool calling is not supported — judges and graders are plain
+    prompt-in/text-out completions.
+    """
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def complete(  # noqa: PLR0912 — linear stream-parse over event kinds
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        timeout_s: float | None = None,
+        effort: str | None = None,
+    ) -> LLMResponse:
+        del tools, effort
+        prompt = "\n\n".join(str(m.get("content", "")) for m in messages)
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--model",
+            self.model,
+            "--sandbox",
+            "read-only",
+            "--skip-git-repo-check",
+            prompt,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s if timeout_s and timeout_s > 0 else 600,
+                env=_codex_env(),
+                check=False,
+            )
+        except FileNotFoundError as e:
+            raise ProviderError("'codex' not found on PATH for judge/grader call") from e
+        except subprocess.TimeoutExpired as e:
+            raise ProviderError("codex judge/grader call timed out") from e
+
+        text = ""
+        prompt_tokens = completion_tokens = 0
+        error_text: str | None = None
+        for raw_line in proc.stdout.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            etype = str(event.get("type") or "")
+            if etype == "item.completed":
+                item = event.get("item") or {}
+                itype = str(item.get("item_type") or item.get("type") or "")
+                if itype in ("assistant_message", "agent_message"):
+                    text = str(item.get("text") or "")
+                elif itype == "error":
+                    error_text = str(item.get("message") or "")
+            elif etype == "turn.completed":
+                p, c = _fold_codex_usage(event.get("usage") or {})
+                prompt_tokens += p
+                completion_tokens += c
+            elif etype in ("turn.failed", "error"):
+                error_text = str(
+                    (event.get("error") or {}).get("message") or event.get("message") or "error"
+                )
+        if error_text and _LIMIT_PATTERN.search(error_text):
+            raise ProviderError(f"codex subscription limit hit: {error_text[:300]}")
+        if proc.returncode != 0:
+            raise ProviderError(
+                f"codex judge call failed (exit {proc.returncode}): "
+                f"{(error_text or proc.stderr or proc.stdout)[-300:]}"
+            )
+        if error_text:
+            raise ProviderError(f"codex judge call errored: {error_text[:300]}")
+        return LLMResponse(
+            content=text or None,
+            usage=TokenUsage(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),
+            raw={"stdout_tail": proc.stdout[-1000:]},
         )

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -32,6 +32,7 @@ from harness.agent.cli_agents import (
     build_cli_prompt,
     is_cli_agent_spec,
     run_claude_code_task,
+    run_codex_task,
 )
 from harness.agent.local_executor import LocalToolExecutor
 from harness.agent.protocol import RunCommandArgs, ToolCall, ToolProtocol, get_openai_tool_schemas
@@ -325,7 +326,8 @@ def _resolve_run_engine(
                 "its own tool execution; pass --sandbox local to acknowledge "
                 "host execution"
             )
-        return True, None, effort_config("claude-code", effort)
+        cli_provider = model.partition(":")[0].strip().lower()
+        return True, None, effort_config(cli_provider, effort)
     provider = provider or get_provider(model)
     return False, provider, effort_config(provider.name, effort)
 
@@ -351,19 +353,33 @@ def _execute_agent(
 ) -> tuple[int, int, bool, bool, CliAgentOutcome | None]:
     """Run the agent phase: the vendor CLI in the workspace, or the model loop."""
     if cli_agent:
-        _, cli_model = parse_model_spec(model)
-        outcome = run_claude_code_task(
-            workspace=workspace,
-            prompt=build_cli_prompt(task.issue),
-            model=cli_model,
-            priced_spec=model,
-            max_turns=effective_max_steps,
-            collector=collector,
-            stream_log_path=run_dir / "cli-agent-stream.jsonl",
-            timeout_s=deadline.remaining_s(),
-            network=network,
-            max_run_cost=max_run_cost,
-        )
+        cli_provider, cli_model = parse_model_spec(model)
+        if cli_provider == "codex":
+            outcome = run_codex_task(
+                workspace=workspace,
+                prompt=build_cli_prompt(task.issue),
+                model=cli_model,
+                priced_spec=model,
+                collector=collector,
+                stream_log_path=run_dir / "cli-agent-stream.jsonl",
+                timeout_s=deadline.remaining_s(),
+                network=network,
+                max_run_cost=max_run_cost,
+                effort=effort_meta.requested if effort_meta else None,
+            )
+        else:
+            outcome = run_claude_code_task(
+                workspace=workspace,
+                prompt=build_cli_prompt(task.issue),
+                model=cli_model,
+                priced_spec=model,
+                max_turns=effective_max_steps,
+                collector=collector,
+                stream_log_path=run_dir / "cli-agent-stream.jsonl",
+                timeout_s=deadline.remaining_s(),
+                network=network,
+                max_run_cost=max_run_cost,
+            )
         if outcome.timed_out:
             deadline.record_exceeded(collector, "cli_agent")
         return (

--- a/harness/agent/providers.py
+++ b/harness/agent/providers.py
@@ -1051,7 +1051,11 @@ def get_provider(spec: str) -> LLMProvider:
         from harness.agent.cli_agents import ClaudeCodeProvider  # noqa: PLC0415
 
         return ClaudeCodeProvider(model)
+    if provider == "codex":
+        from harness.agent.cli_agents import CodexProvider  # noqa: PLC0415
+
+        return CodexProvider(model)
     if provider not in _PROVIDERS:
-        known = ", ".join(sorted([*_PROVIDERS, "claude-code"]))
+        known = ", ".join(sorted([*_PROVIDERS, "claude-code", "codex"]))
         raise ValueError(f"unknown provider {provider!r}; known: {known}")
     return _PROVIDERS[provider](model)

--- a/harness/effort.py
+++ b/harness/effort.py
@@ -70,6 +70,13 @@ _PROVIDER_EFFORT_MAPS = {
     "deepseek": _DEEPSEEK_EFFORT_VALUES,
     "qwen": _QWEN_EFFORT_VALUES,
     "xai": _XAI_EFFORT_VALUES,
+    # Codex CLI: config key model_reasoning_effort (low/medium/high/xhigh).
+    "codex": {
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "extra-high": "xhigh",
+    },
 }
 
 

--- a/harness/pricing.py
+++ b/harness/pricing.py
@@ -79,7 +79,7 @@ _PER_MILLION = 1_000_000.0
 # rates, so their ``cost_usd`` is the *hypothetical* API cost of the same
 # tokens. The run summary marks these with ``cli_agent.billing`` so the
 # number is never mistaken for actual spend.
-_SPEC_ALIASES = {"claude-code:": "anthropic:"}
+_SPEC_ALIASES = {"claude-code:": "anthropic:", "codex:": "openai:"}
 
 
 def _canonical_spec(model: str) -> str:

--- a/harness/task_metadata.py
+++ b/harness/task_metadata.py
@@ -44,37 +44,70 @@ SCALE_DEFAULTS: dict[str, dict[str, int | float]] = {
     "large": {"suggested_max_steps": 150, "suggested_timeout_s": 2700},
     "xlarge": {"suggested_max_steps": 200, "suggested_timeout_s": 3600},
 }
-# Complexity-scaled budgets (Coding Intelligence Index): repo_scale sets the
-# baseline (navigation surface drives per-step cost), and task_complexity
-# multiplies it (a cross-module fix needs more of those steps than a one-file
-# edit in the same tree). The v3/v4 timeout failures were exactly this gap: a
-# `system` task in a medium repo got the same 1200s as a one-liner. These
-# multipliers are used to STAMP explicit `agent_hints` into each task
-# (scripts/stamp_task_budgets.py) rather than applied at run time, so a task's
-# budget is auditable in its metadata and older suites' run conditions never
-# shift under cached-run comparisons.
-COMPLEXITY_BUDGET_MULTIPLIERS: dict[str, float] = {
-    "localized": 1.0,
-    "multi_file": 1.3,
-    "system": 1.6,
-    "architecture": 2.0,
+# Complexity-scaled budgets (Coding Intelligence Index), TerminalBench-style:
+# generous wall-clock allowances in tidy half-hour increments, so a slow
+# verdict always means the model could not solve the task — never that the
+# clock was tuned to the median solver. TerminalBench's published budgets
+# cluster at 2h with a tail from 30min to 8h; this formula reproduces that
+# shape from the task's declared complexity (dominant factor), difficulty and
+# repo scale. These values are used to STAMP explicit `agent_hints` into each
+# task (scripts/stamp_task_budgets.py) rather than applied at run time, so a
+# task's budget is auditable in its metadata and older suites' run conditions
+# never shift under cached-run comparisons.
+CII_COMPLEXITY_BASE_MINUTES: dict[str, int] = {
+    "localized": 60,
+    "multi_file": 120,
+    "system": 150,
+    "architecture": 240,
 }
+CII_DIFFICULTY_MULTIPLIERS: dict[str, float] = {
+    "easy": 0.5,
+    "medium": 1.0,
+    "hard": 1.5,
+    "veryhard": 2.0,
+}
+CII_SCALE_MULTIPLIERS: dict[str, float] = {
+    "micro": 0.75,
+    "small": 0.75,
+    "medium": 1.0,
+    "large": 1.25,
+    "xlarge": 1.5,
+}
+CII_MIN_MINUTES = 30
+CII_MAX_MINUTES = 480  # 8h, TerminalBench's ceiling
+# Step allowance follows the clock at a measured ~20s per step (model round
+# trip + tool call), rounded to tens so stamped values read cleanly.
+CII_SECONDS_PER_STEP = 20
 
 
-def complexity_scaled_budgets(scale: str, complexity: str) -> dict[str, int]:
-    """Explicit per-task budgets from the scale baseline x complexity multiplier.
+def task_difficulty(metadata: dict[str, Any]) -> str:
+    """Normalized difficulty tier; unknown/missing values read as ``medium``."""
+    raw = str(metadata.get("difficulty") or "").strip().lower()
+    if raw in CII_DIFFICULTY_MULTIPLIERS:
+        return raw
+    return "medium"
+
+
+def complexity_scaled_budgets(
+    scale: str, complexity: str, difficulty: str = "medium"
+) -> dict[str, int]:
+    """Explicit per-task budgets: complexity base x difficulty x repo scale.
 
     Returns ``{"suggested_max_steps": int, "suggested_timeout_s": int}`` suitable
-    for stamping into ``metadata.agent_hints``. Unknown scales fall back to the
-    micro baseline and unknown complexities to x1.0, mirroring ``repo_scale()``
-    and ``task_complexity()`` normalization. Timeouts round up to a whole minute
-    so stamped values read cleanly in metadata.
+    for stamping into ``metadata.agent_hints``. Minutes are rounded UP to
+    half-hour increments and clamped to [30min, 8h]; unknown inputs normalize
+    the same way :func:`repo_scale` / :func:`task_complexity` /
+    :func:`task_difficulty` do (localized / medium / micro-like conservative
+    defaults).
     """
-    base = SCALE_DEFAULTS.get(scale, SCALE_DEFAULTS["micro"])
-    mult = COMPLEXITY_BUDGET_MULTIPLIERS.get(complexity, 1.0)
-    steps = round(float(base["suggested_max_steps"]) * mult)
-    timeout = float(base["suggested_timeout_s"]) * mult
-    timeout_s = int(-(-timeout // 60) * 60)  # ceil to whole minutes
+    base = CII_COMPLEXITY_BASE_MINUTES.get(complexity, CII_COMPLEXITY_BASE_MINUTES["localized"])
+    d_mult = CII_DIFFICULTY_MULTIPLIERS.get(difficulty, 1.0)
+    s_mult = CII_SCALE_MULTIPLIERS.get(scale, 1.0)
+    minutes = base * d_mult * s_mult
+    minutes = min(max(minutes, CII_MIN_MINUTES), CII_MAX_MINUTES)
+    minutes = int(-(-minutes // 30) * 30)  # ceil to half-hour increments
+    timeout_s = minutes * 60
+    steps = int(-(-(timeout_s / CII_SECONDS_PER_STEP) // 10) * 10)  # ceil to tens
     return {"suggested_max_steps": steps, "suggested_timeout_s": timeout_s}
 
 

--- a/scripts/stamp_task_budgets.py
+++ b/scripts/stamp_task_budgets.py
@@ -35,6 +35,7 @@ from harness.task_metadata import (
     complexity_scaled_budgets,
     repo_scale,
     task_complexity,
+    task_difficulty,
 )
 
 
@@ -51,7 +52,9 @@ def stamp(task_dir: Path, check: bool) -> str:
     hints = metadata.get("agent_hints")
     if not isinstance(hints, dict):
         hints = {}
-    expected = complexity_scaled_budgets(repo_scale(metadata), task_complexity(metadata))
+    expected = complexity_scaled_budgets(
+        repo_scale(metadata), task_complexity(metadata), task_difficulty(metadata)
+    )
 
     if hints.get("budget_hand_tuned") is True:
         return "hand-tuned"

--- a/tasks/cii-v1/oss-anyio-create-task-names/metadata.json
+++ b/tasks/cii-v1/oss-anyio-create-task-names/metadata.json
@@ -60,7 +60,7 @@
       "src/anyio/abc/_tasks.py",
       "src/anyio/_backends/"
     ],
-    "suggested_max_steps": 240,
-    "suggested_timeout_s": 4320
+    "suggested_max_steps": 630,
+    "suggested_timeout_s": 12600
   }
 }

--- a/tasks/cii-v1/oss-axios-methodlist-adapter-errors/metadata.json
+++ b/tasks/cii-v1/oss-axios-methodlist-adapter-errors/metadata.json
@@ -64,7 +64,7 @@
       "lib/core/",
       "lib/adapters/http.js"
     ],
-    "suggested_max_steps": 240,
-    "suggested_timeout_s": 4320
+    "suggested_max_steps": 630,
+    "suggested_timeout_s": 12600
   }
 }

--- a/tasks/cii-v1/oss-bitflags-iter-equal-names/metadata.json
+++ b/tasks/cii-v1/oss-bitflags-iter-equal-names/metadata.json
@@ -63,7 +63,7 @@
       "src/iter.rs",
       "src/traits.rs"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 270,
+    "suggested_timeout_s": 5400
   }
 }

--- a/tasks/cii-v1/oss-bodyparser-limit-validation/metadata.json
+++ b/tasks/cii-v1/oss-bodyparser-limit-validation/metadata.json
@@ -51,7 +51,7 @@
     "entry_paths": [
       "lib/types/"
     ],
-    "suggested_max_steps": 160,
-    "suggested_timeout_s": 1920
+    "suggested_max_steps": 450,
+    "suggested_timeout_s": 9000
   }
 }

--- a/tasks/cii-v1/oss-chi-query-method/metadata.json
+++ b/tasks/cii-v1/oss-chi-query-method/metadata.json
@@ -64,7 +64,7 @@
       "mux.go",
       "tree.go"
     ],
-    "suggested_max_steps": 160,
-    "suggested_timeout_s": 1920
+    "suggested_max_steps": 450,
+    "suggested_timeout_s": 9000
   }
 }

--- a/tasks/cii-v1/oss-clap-mangen-override-usage/metadata.json
+++ b/tasks/cii-v1/oss-clap-mangen-override-usage/metadata.json
@@ -67,7 +67,7 @@
       "clap_mangen/src/render.rs",
       "clap_builder/src/builder/command.rs"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 720,
+    "suggested_timeout_s": 14400
   }
 }

--- a/tasks/cii-v1/oss-cli-arg-validator/metadata.json
+++ b/tasks/cii-v1/oss-cli-arg-validator/metadata.json
@@ -68,7 +68,7 @@
       "command.go",
       "command_run.go"
     ],
-    "suggested_max_steps": 240,
-    "suggested_timeout_s": 4320
+    "suggested_max_steps": 630,
+    "suggested_timeout_s": 12600
   }
 }

--- a/tasks/cii-v1/oss-cli-required-single-arg/metadata.json
+++ b/tasks/cii-v1/oss-cli-required-single-arg/metadata.json
@@ -60,7 +60,7 @@
       "args.go",
       "command_run.go"
     ],
-    "suggested_max_steps": 240,
-    "suggested_timeout_s": 4320
+    "suggested_max_steps": 630,
+    "suggested_timeout_s": 12600
   }
 }

--- a/tasks/cii-v1/oss-click-custom-version-option/metadata.json
+++ b/tasks/cii-v1/oss-click-custom-version-option/metadata.json
@@ -58,7 +58,7 @@
     "entry_paths": [
       "src/click/decorators.py"
     ],
-    "suggested_max_steps": 195,
-    "suggested_timeout_s": 3540
+    "suggested_max_steps": 450,
+    "suggested_timeout_s": 9000
   }
 }

--- a/tasks/cii-v1/oss-echo-group-implicit-overwrite/metadata.json
+++ b/tasks/cii-v1/oss-echo-group-implicit-overwrite/metadata.json
@@ -56,7 +56,7 @@
       "group.go",
       "router.go"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 720,
+    "suggested_timeout_s": 14400
   }
 }

--- a/tasks/cii-v1/oss-echo-problem-details/metadata.json
+++ b/tasks/cii-v1/oss-echo-problem-details/metadata.json
@@ -71,7 +71,7 @@
     "entry_paths": [
       "echo.go"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 540,
+    "suggested_timeout_s": 10800
   }
 }

--- a/tasks/cii-v1/oss-eslint-loop-condition-ternary/metadata.json
+++ b/tasks/cii-v1/oss-eslint-loop-condition-ternary/metadata.json
@@ -59,7 +59,7 @@
     "entry_paths": [
       "lib/rules/no-unmodified-loop-condition.js"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 540,
+    "suggested_timeout_s": 10800
   }
 }

--- a/tasks/cii-v1/oss-eslint-property-descriptor-scope/metadata.json
+++ b/tasks/cii-v1/oss-eslint-property-descriptor-scope/metadata.json
@@ -67,7 +67,7 @@
     "entry_paths": [
       "lib/rules/utils/ast-utils.js"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 1080,
+    "suggested_timeout_s": 21600
   }
 }

--- a/tasks/cii-v1/oss-hono-regexp-wildcard-middleware/metadata.json
+++ b/tasks/cii-v1/oss-hono-regexp-wildcard-middleware/metadata.json
@@ -71,7 +71,7 @@
     "entry_paths": [
       "src/router/reg-exp-router/"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 810,
+    "suggested_timeout_s": 16200
   }
 }

--- a/tasks/cii-v1/oss-hono-trie-suffix-wildcard/metadata.json
+++ b/tasks/cii-v1/oss-hono-trie-suffix-wildcard/metadata.json
@@ -59,7 +59,7 @@
     "entry_paths": [
       "src/router/trie-router/"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 540,
+    "suggested_timeout_s": 10800
   }
 }

--- a/tasks/cii-v1/oss-hono-wildcard-prefix-overmatch/metadata.json
+++ b/tasks/cii-v1/oss-hono-wildcard-prefix-overmatch/metadata.json
@@ -72,7 +72,7 @@
       "src/router/linear-router/router.ts",
       "src/router/pattern-router/router.ts"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 540,
+    "suggested_timeout_s": 10800
   }
 }

--- a/tasks/cii-v1/oss-jiff-offset-subtraction/metadata.json
+++ b/tasks/cii-v1/oss-jiff-offset-subtraction/metadata.json
@@ -62,7 +62,7 @@
     "entry_paths": [
       "crates/jiff-core/src/tz/offset.rs"
     ],
-    "suggested_max_steps": 200,
+    "suggested_max_steps": 180,
     "suggested_timeout_s": 3600
   }
 }

--- a/tasks/cii-v1/oss-ky-query-method/metadata.json
+++ b/tasks/cii-v1/oss-ky-query-method/metadata.json
@@ -55,7 +55,7 @@
     "entry_paths": [
       "source/core/constants.ts"
     ],
-    "suggested_max_steps": 160,
-    "suggested_timeout_s": 1920
+    "suggested_max_steps": 450,
+    "suggested_timeout_s": 9000
   }
 }

--- a/tasks/cii-v1/oss-networkx-digraph-node-cuts/metadata.json
+++ b/tasks/cii-v1/oss-networkx-digraph-node-cuts/metadata.json
@@ -78,7 +78,7 @@
     "entry_paths": [
       "networkx/algorithms/connectivity/"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 810,
+    "suggested_timeout_s": 16200
   }
 }

--- a/tasks/cii-v1/oss-packaging-interpreter-tag-identifier/metadata.json
+++ b/tasks/cii-v1/oss-packaging-interpreter-tag-identifier/metadata.json
@@ -66,7 +66,7 @@
     "entry_paths": [
       "src/packaging/tags.py"
     ],
-    "suggested_max_steps": 130,
-    "suggested_timeout_s": 1560
+    "suggested_max_steps": 180,
+    "suggested_timeout_s": 3600
   }
 }

--- a/tasks/cii-v1/oss-pydantic-none-discriminator/metadata.json
+++ b/tasks/cii-v1/oss-pydantic-none-discriminator/metadata.json
@@ -63,7 +63,7 @@
     "entry_paths": [
       "pydantic/_internal/_discriminated_union.py"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 810,
+    "suggested_timeout_s": 16200
   }
 }

--- a/tasks/cii-v1/oss-pygments-transparent-color/metadata.json
+++ b/tasks/cii-v1/oss-pygments-transparent-color/metadata.json
@@ -58,7 +58,7 @@
     "entry_paths": [
       "pygments/style.py"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 270,
+    "suggested_timeout_s": 5400
   }
 }

--- a/tasks/cii-v1/oss-regex-static-macro/metadata.json
+++ b/tasks/cii-v1/oss-regex-static-macro/metadata.json
@@ -71,7 +71,7 @@
       "src/lib.rs",
       "src/regex/string.rs"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 720,
+    "suggested_timeout_s": 14400
   }
 }

--- a/tasks/cii-v1/oss-sqlglot-multi-table-ddl/metadata.json
+++ b/tasks/cii-v1/oss-sqlglot-multi-table-ddl/metadata.json
@@ -71,7 +71,7 @@
       "sqlglot/parser.py",
       "sqlglot/generator.py"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 1080,
+    "suggested_timeout_s": 21600
   }
 }

--- a/tasks/cii-v1/oss-toml-value-datetime-deserialize/metadata.json
+++ b/tasks/cii-v1/oss-toml-value-datetime-deserialize/metadata.json
@@ -66,7 +66,7 @@
     "entry_paths": [
       "crates/toml/src/"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 540,
+    "suggested_timeout_s": 10800
   }
 }

--- a/tasks/cii-v1/oss-undici-body-sent-hooks/metadata.json
+++ b/tasks/cii-v1/oss-undici-body-sent-hooks/metadata.json
@@ -51,7 +51,7 @@
     "entry_paths": [
       "lib/handler/decorator-handler.js"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 720,
+    "suggested_timeout_s": 14400
   }
 }

--- a/tasks/cii-v1/oss-undici-interceptors-origin/metadata.json
+++ b/tasks/cii-v1/oss-undici-interceptors-origin/metadata.json
@@ -52,7 +52,7 @@
       "lib/interceptor/cache.js",
       "lib/interceptor/deduplicate.js"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 1080,
+    "suggested_timeout_s": 21600
   }
 }

--- a/tasks/cii-v1/oss-zod-codepoint-length/metadata.json
+++ b/tasks/cii-v1/oss-zod-codepoint-length/metadata.json
@@ -75,7 +75,7 @@
     "entry_paths": [
       "packages/zod/src/v4/core/checks.ts"
     ],
-    "suggested_max_steps": 320,
-    "suggested_timeout_s": 5760
+    "suggested_max_steps": 1080,
+    "suggested_timeout_s": 21600
   }
 }

--- a/tasks/cii-v1/oss-zod-exactoptional-absent-key/metadata.json
+++ b/tasks/cii-v1/oss-zod-exactoptional-absent-key/metadata.json
@@ -75,7 +75,7 @@
     "entry_paths": [
       "packages/zod/src/v4/core/schemas.ts"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 810,
+    "suggested_timeout_s": 16200
   }
 }

--- a/tasks/cii-v1/oss-zod-url-ipv6-validated-string/metadata.json
+++ b/tasks/cii-v1/oss-zod-url-ipv6-validated-string/metadata.json
@@ -63,7 +63,7 @@
     "entry_paths": [
       "packages/zod/src/v4/core/schemas.ts"
     ],
-    "suggested_max_steps": 260,
-    "suggested_timeout_s": 4680
+    "suggested_max_steps": 810,
+    "suggested_timeout_s": 16200
   }
 }

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,0 +1,195 @@
+"""Tests for the Codex agent-CLI runner (``codex:`` specs).
+
+A fake ``codex`` binary on PATH emits canned JSONL events (and writes the
+hello-world solution), so the full run_agent pipeline — workspace, diff,
+verifier, scoring, hypothetical-API pricing — is exercised offline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from harness.agent.cli_agents import is_cli_agent_spec, run_codex_task
+from harness.agent.loop import run_agent
+from harness.agent.providers import ProviderError, get_provider
+from harness.pricing import cost_usd
+from harness.sandbox.docker_executor import SandboxError
+
+# turn.completed usage: input 200 with 100 cached folds to
+# round((200-100) + 100*0.1) = 110 effective prompt tokens; output 40.
+FAKE_CODEX = """#!/usr/bin/env python3
+import json, os, sys
+
+args = sys.argv[1:]
+mode = os.environ.get("FAKE_CODEX_MODE", "success")
+api_key_present = "OPENAI_API_KEY" in os.environ
+usage = {"input_tokens": 200, "cached_input_tokens": 100, "output_tokens": 40}
+
+print(json.dumps({"type": "thread.started", "thread_id": "th1",
+                  "api_key_present": api_key_present}))
+if mode == "success":
+    with open("hello.py", "w") as f:
+        f.write('print("hello from vulcanbench")\\n')
+print(json.dumps({"type": "item.completed", "item": {
+    "id": "i1", "item_type": "command_execution",
+    "command": "echo hi", "aggregated_output": "hi", "exit_code": 0}}))
+print(json.dumps({"type": "item.completed", "item": {
+    "id": "i2", "item_type": "agent_message", "text": "Wrote the file"}}))
+if mode == "limit":
+    print(json.dumps({"type": "error",
+                      "message": "You've hit your usage limit. Try again later."}))
+    sys.exit(1)
+if mode == "fail":
+    print(json.dumps({"type": "turn.failed", "error": {"message": "model exploded"}}))
+    sys.exit(1)
+print(json.dumps({"type": "turn.completed", "usage": usage}))
+"""
+
+
+class _Collector:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def record(self, event_type: str, data: dict[str, Any]) -> None:
+        self.events.append((event_type, data))
+
+
+@pytest.fixture()
+def fake_codex(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bin_dir = tmp_path_factory.mktemp("fakebin")
+    script = bin_dir / "codex"
+    script.write_text(FAKE_CODEX, encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    # Must be stripped from the CLI subprocess env (subscription auth only).
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-should-be-stripped")
+    monkeypatch.delenv("FAKE_CODEX_MODE", raising=False)
+    return script
+
+
+def test_spec_detection() -> None:
+    assert is_cli_agent_spec("codex:gpt-5.6-sol")
+    assert not is_cli_agent_spec("openai:gpt-5.6-sol")
+
+
+def test_pricing_alias_maps_to_openai_rates() -> None:
+    api = cost_usd("openai:gpt-4o", 1000, 1000)
+    cli = cost_usd("codex:gpt-4o", 1000, 1000)
+    assert api is not None
+    assert cli == api
+
+
+def test_run_codex_task_success(tmp_path: Path, fake_codex: Path) -> None:
+    collector = _Collector()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    outcome = run_codex_task(
+        workspace=ws,
+        prompt="do the thing",
+        model="gpt-5.6-sol",
+        priced_spec="codex:gpt-5.6-sol",
+        collector=collector,
+        stream_log_path=tmp_path / "stream.jsonl",
+    )
+    assert outcome.finished
+    assert outcome.harness == "codex"
+    assert outcome.session_id == "th1"
+    assert outcome.num_turns == 1
+    assert (outcome.prompt_tokens, outcome.completion_tokens) == (110, 40)
+    assert (ws / "hello.py").exists()
+    kinds = [k for k, _ in collector.events]
+    assert "cli_agent_start" in kinds
+    assert "llm_response" in kinds
+    assert "tool_observation" in kinds
+    # The stream log captured the raw events.
+    assert (tmp_path / "stream.jsonl").read_text().count("\n") >= 4
+
+
+def test_openai_key_stripped_from_subprocess(tmp_path: Path, fake_codex: Path) -> None:
+    collector = _Collector()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    run_codex_task(
+        workspace=ws,
+        prompt="p",
+        model="m",
+        priced_spec="codex:m",
+        collector=collector,
+        stream_log_path=tmp_path / "s.jsonl",
+    )
+    first = json.loads((tmp_path / "s.jsonl").read_text().splitlines()[0])
+    assert first["api_key_present"] is False
+
+
+def test_usage_limit_raises_provider_error(
+    tmp_path: Path, fake_codex: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAKE_CODEX_MODE", "limit")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    with pytest.raises(ProviderError, match="subscription limit"):
+        run_codex_task(
+            workspace=ws,
+            prompt="p",
+            model="m",
+            priced_spec="codex:m",
+            collector=_Collector(),
+        )
+
+
+def test_turn_failure_raises_provider_error(
+    tmp_path: Path, fake_codex: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAKE_CODEX_MODE", "fail")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    with pytest.raises(ProviderError):
+        run_codex_task(
+            workspace=ws,
+            prompt="p",
+            model="m",
+            priced_spec="codex:m",
+            collector=_Collector(),
+        )
+
+
+def test_run_agent_via_codex(tmp_path: Path, fake_codex: Path) -> None:
+    result = run_agent(
+        task_id="hello-world",
+        model="codex:gpt-5.6-sol",
+        output_dir=tmp_path / "runs",
+        sandbox="local",
+        judges=False,
+    )
+    summary = result["summary"]
+    assert summary["scores"]["functional"] == 1.0
+    assert summary["cli_agent"]["harness"] == "codex"
+    assert summary["cli_agent"]["billing"] == "subscription"
+
+
+def test_codex_requires_local_sandbox(tmp_path: Path, fake_codex: Path) -> None:
+    with pytest.raises(SandboxError, match="--sandbox local"):
+        run_agent(
+            task_id="hello-world",
+            model="codex:gpt-5.6-sol",
+            output_dir=tmp_path / "runs",
+            sandbox="docker",
+            judges=False,
+        )
+
+
+def test_codex_judge_provider_single_shot(fake_codex: Path) -> None:
+    provider = get_provider("codex:gpt-5.6-sol")
+    response = provider.complete(
+        [{"role": "user", "content": "rate this"}],
+        tools=[],
+    )
+    assert response.content == "Wrote the file"
+    assert response.usage.prompt_tokens == 110
+    assert response.usage.completion_tokens == 40

--- a/tests/test_task_metadata.py
+++ b/tests/test_task_metadata.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 
 from harness.task_metadata import (
-    COMPLEXITY_BUDGET_MULTIPLIERS,
+    CII_COMPLEXITY_BASE_MINUTES,
+    CII_DIFFICULTY_MULTIPLIERS,
     SCALE_DEFAULTS,
     complexity_scaled_budgets,
     infer_task_complexity_from_gold_patch,
@@ -14,6 +15,7 @@ from harness.task_metadata import (
     resolve_max_steps,
     resolve_verifier_timeout_s,
     task_complexity,
+    task_difficulty,
     validate_scale_fields,
 )
 
@@ -146,26 +148,45 @@ def test_bigger_repos_get_at_least_as_much_wall_clock() -> None:
 
 
 def test_complexity_scaled_budgets_formula() -> None:
-    # localized keeps the scale baseline exactly.
-    base = complexity_scaled_budgets("medium", "localized")
-    assert base == {"suggested_max_steps": 100, "suggested_timeout_s": 1200}
-    # system multiplies it (1200 * 1.6 = 1920, already a whole minute).
-    system = complexity_scaled_budgets("medium", "system")
-    assert system == {"suggested_max_steps": 160, "suggested_timeout_s": 1920}
-    # Timeouts round UP to whole minutes (300 * 1.3 = 390 -> 420).
-    assert complexity_scaled_budgets("micro", "multi_file")["suggested_timeout_s"] == 420
-    # architecture at xlarge is the ceiling: 2h, 400 steps.
-    top = complexity_scaled_budgets("xlarge", "architecture")
-    assert top == {"suggested_max_steps": 400, "suggested_timeout_s": 7200}
-    # Unknown values normalize like repo_scale()/task_complexity() do.
-    assert complexity_scaled_budgets("bogus", "bogus") == complexity_scaled_budgets(
-        "micro", "localized"
+    # TerminalBench-style: complexity base x difficulty x scale, half-hour
+    # increments, clamped to [30min, 8h].
+    # medium multi_file at medium difficulty: 120min * 1.0 * 1.0 = 2h.
+    assert complexity_scaled_budgets("medium", "multi_file") == {
+        "suggested_max_steps": 360,
+        "suggested_timeout_s": 7200,
+    }
+    # Easy localized on a small repo clamps up to the 30min floor.
+    assert complexity_scaled_budgets("small", "localized", "easy")["suggested_timeout_s"] == 1800
+    # Hard system on an xlarge repo: 150 * 1.5 * 1.5 = 337.5 -> 360min = 6h.
+    assert complexity_scaled_budgets("xlarge", "system", "hard")["suggested_timeout_s"] == 21600
+    # veryhard architecture on xlarge hits the 8h ceiling (240*2*1.5 = 720 -> 480).
+    assert complexity_scaled_budgets("xlarge", "architecture", "veryhard") == {
+        "suggested_max_steps": 1440,
+        "suggested_timeout_s": 28800,
+    }
+    # Steps track the clock at ~20s/step, rounded to tens.
+    b = complexity_scaled_budgets("large", "system", "medium")  # 150*1.25=187.5 -> 210min
+    assert b["suggested_timeout_s"] == 12600
+    assert b["suggested_max_steps"] == 630
+    # Unknown values normalize conservatively.
+    assert complexity_scaled_budgets("bogus", "bogus", "bogus") == complexity_scaled_budgets(
+        "medium", "localized", "medium"
     )
-    # Budgets are monotone in complexity for every scale.
-    order = ["localized", "multi_file", "system", "architecture"]
-    assert [COMPLEXITY_BUDGET_MULTIPLIERS[c] for c in order] == sorted(
-        COMPLEXITY_BUDGET_MULTIPLIERS[c] for c in order
+    # Budgets are monotone in complexity and difficulty.
+    order_c = ["localized", "multi_file", "system", "architecture"]
+    assert [CII_COMPLEXITY_BASE_MINUTES[c] for c in order_c] == sorted(
+        CII_COMPLEXITY_BASE_MINUTES[c] for c in order_c
     )
+    order_d = ["easy", "medium", "hard", "veryhard"]
+    assert [CII_DIFFICULTY_MULTIPLIERS[d] for d in order_d] == sorted(
+        CII_DIFFICULTY_MULTIPLIERS[d] for d in order_d
+    )
+
+
+def test_task_difficulty_normalizes() -> None:
+    assert task_difficulty({}) == "medium"
+    assert task_difficulty({"difficulty": "VeryHard"}) == "veryhard"
+    assert task_difficulty({"difficulty": "impossible"}) == "medium"
 
 
 def test_suite_requiring_explicit_budgets_fails_unstamped_task(tmp_path) -> None:


### PR DESCRIPTION
Two changes preparing the Coding Intelligence Index for its first real measurement.

## TerminalBench-style budgets
The original stamped budgets (26min–96min) were tuned like v3's — too tight. The formula is now **complexity base × difficulty × repo scale**, in half-hour increments clamped to [30min, 8h]:

| Factor | Values |
|---|---|
| complexity base | localized 1h · multi_file 2h · system 2.5h · architecture 4h |
| difficulty | easy ×0.5 · medium ×1.0 · hard ×1.5 · veryhard ×2.0 |
| repo scale | micro/small ×0.75 · medium ×1.0 · large ×1.25 · xlarge ×1.5 |

All 30 tasks restamped. Resulting distribution (TerminalBench's shape, scaled to this suite's complexity-heavy mix):

```
 1.0h: 2   1.5h: 2   2.5h: 4   3.0h: 5   3.5h: 4   4.0h: 4   4.5h: 5   6.0h: 4
```

`SCALE_DEFAULTS` is untouched — v1–v4 run conditions don't move. Steps track the clock at ~20s/step.

## `codex:` CLI agent (subscription billing)
Mirrors the `claude-code:` path so **GPT 5.6 Sol runs on a ChatGPT subscription** instead of API rates:
- `codex:gpt-5.6-sol` runs tasks via `codex exec --json` headless in Codex's workspace-write sandbox (writes confined to the workspace, network off unless `--network`), with the wall-clock watchdog, cost-cap, and trace streaming the claude-code path has.
- `OPENAI_API_KEY` is stripped from the subprocess (subscription auth only); usage-limit hits surface as resumable errors, never scored zeros.
- Priced hypothetically at `openai:` rates; harness recorded in the summary so CLI columns can't be mixed with API columns; effort maps to the CLI's `model_reasoning_effort`.
- `CodexProvider` handles single-shot judge/grader calls (read-only sandbox) — though the hardness measurement should run `--no-judges` to focus purely on functional accuracy.
- 9 offline tests with a fake `codex` binary exercise the full run_agent pipeline.

## Test plan
- [x] `make test` — 604 passed (incl. 9 new codex tests)
- [x] `make lint` + strict mypy clean
- [x] `stamp_task_budgets.py --check` consistent across all 30 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)