### PR TITLE
CII: gitignore node_modules in JS deps-task repos

### DIFF
--- a/tasks/cii-v1/oss-axios-methodlist-adapter-errors/repo/.gitignore
+++ b/tasks/cii-v1/oss-axios-methodlist-adapter-errors/repo/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tasks/cii-v1/oss-bodyparser-limit-validation/repo/.gitignore
+++ b/tasks/cii-v1/oss-bodyparser-limit-validation/repo/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tasks/cii-v1/oss-eslint-loop-condition-ternary/repo/.gitignore
+++ b/tasks/cii-v1/oss-eslint-loop-condition-ternary/repo/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tasks/cii-v1/oss-eslint-property-descriptor-scope/repo/.gitignore
+++ b/tasks/cii-v1/oss-eslint-property-descriptor-scope/repo/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Tiny guard: CLI-agent runs (`codex:`/`claude-code:`, subscription billing) execute host-side, so the four JS deps-tasks (eslint ×2, axios, body-parser) get `node_modules` installed into their `repo/` for host verifier resolution. These `.gitignore` entries make them uncommittable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)