### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+VulcanBench is a Python 3.12 LLM benchmarking harness. Standard commands live in
+the root `Makefile` and `README.md` (`make help` lists everything). This section
+only captures non-obvious caveats for working in the cloud environment.
+
+### Services
+
+- `vulcanbench` CLI (core product, Python). Activate the venv first:
+  `source .venv/bin/activate`, then `vulcanbench --help`.
+- FastAPI backend (`backend/app.py`), optional — powers the dashboard.
+- Next.js dashboard (`dashboard/`), optional web UI. See `dashboard/AGENTS.md`
+  (this is Next.js 16 with breaking changes vs. common knowledge).
+
+### Non-obvious caveats
+
+- The update script already creates `.venv` and installs the harness in editable
+  mode. Activate it with `source .venv/bin/activate` before running `vulcanbench`,
+  `pytest`, `ruff`, or `mypy`. The `Makefile` targets also work without activation
+  because they put `.venv/bin` on `PATH`.
+- The venv is installed with the `dev,test,backend` extras (not just `dev,test`
+  from `make setup`). The `backend` extra (fastapi/uvicorn/sqlmodel) is required
+  to run the API with `uvicorn backend.app:app --port 8000`.
+- Docker is NOT available in this environment. Real benchmark runs default to
+  `--sandbox docker` and will error out. For offline testing use the local
+  sandbox + mock provider: `vulcanbench run --task hello-world --model mock:synthetic --sandbox local`.
+  Consequently `make sandbox-image*`, `make docker-up` (Postgres), and
+  `validate-tasks-docker`/`validate-cyber` cannot run here without a Docker daemon.
+- The backend serves the filesystem `./runs/` directory by default (store =
+  `filesystem`, no DB needed). Health check: `GET /api/health`. Postgres/`DATABASE_URL`
+  is only needed for the durable DB store and its write endpoints.
+- The dashboard needs `dashboard/.env.local` (copy from `dashboard/.env.example`);
+  `NEXT_PUBLIC_API_BASE` must point at the backend (default `http://localhost:8000`).
+  Start it with `cd dashboard && npm run dev` (serves `http://localhost:3000`).
+- `make lint` (ruff) and the fast test suite are clean. `make typecheck` (mypy)
+  can report a spurious `unused-ignore` in `alembic/env.py` because mypy is not
+  pinned and a newer version resolves the ignored import differently — this is
+  environment version drift, not a code defect.
+- The fast test suite (`make test` / `pytest -m "not slow and not docker"`) takes
+  roughly 6 minutes and enforces >=80% coverage on `harness`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for VulcanBench and documents non-obvious startup/run caveats for future agents. The only code/repo change is a new root `AGENTS.md`; the dependency-refresh steps live in the environment update script (not committed). No application code was modified.

## Type of change
- [x] Documentation only
- [x] Refactor / DX

## What was set up

- Python venv (`.venv`) with the harness installed editable (`pip install -e ".[dev,test,backend]"`). The `backend` extra is included so the FastAPI API can run.
- Installed the missing system package `python3.12-venv` (one-off; baked into the VM snapshot).
- Dashboard deps via `npm ci` in `dashboard/`.
- Environment update script (run on VM startup): venv create + editable install + `npm ci --prefix dashboard`.

## Verification (agreed scope: CLI core + backend + dashboard)

| Component | Command | Result |
| --- | --- | --- |
| Harness lint | `ruff check . && ruff format --check .` | pass (153 files formatted) |
| Harness tests | `pytest -m "not slow and not docker" --cov=harness` | 604 passed, coverage 84.59% (>=80%) |
| CLI (core) | `vulcanbench run --task hello-world --model mock:synthetic --sandbox local` | run complete, total=0.974, artifacts written |
| Backend | `uvicorn backend.app:app --port 8000` | `/api/health` -> `{"status":"ok","store":"filesystem"}` |
| Dashboard | `npm run dev` (Next.js 16) | ready on :3000, renders live leaderboard from backend |

Note: `mypy` reports one spurious `unused-ignore` in `alembic/env.py` due to mypy version drift (unpinned, newer version) — documented in `AGENTS.md`, not a code defect. Docker is unavailable in this environment, so Docker-sandbox runs, Postgres, and `validate-*-docker` targets are out of scope here.

## Related issues
Closes #

## Checklist
- [x] Docs updated (added `AGENTS.md`)
- [x] No secrets or large binaries committed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5afc243-8669-480e-b5f0-20783b4ef3f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5afc243-8669-480e-b5f0-20783b4ef3f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

