### PR TITLE
Phase 2: multi-service docker-compose task environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-service task environments** (`harness/environment.py`): tasks can
+  declare `metadata.environment` with a docker-compose file and readiness
+  probes. The harness brings the stack up under a unique per-run project
+  before the agent's clock starts, resolves ephemeral published ports into a
+  gitignored `.vb_services.json` in the workspace, and always tears down with
+  `down -v` — in `vulcanbench run` and in task validation (fresh stack per
+  gold/base/determinism run). Validation rejects the isolation footguns
+  (`container_name`, fixed host ports). Environment tasks require
+  `--sandbox local`; the walking-skeleton template is
+  `tasks/cii-v2/demo-compose-redis-smoke`.
+
 - **Coding Intelligence Index v1** (`tasks/cii-v1/`, `--suite cii-v1`): 38 all-new
   gold-verified tasks from post-cutoff OSS PRs (May to Aug 2026) with
   complexity-scaled TB-style budgets; August 2026 frontier results published in

--- a/docs/TASK_CONTRIBUTION.md
+++ b/docs/TASK_CONTRIBUTION.md
@@ -164,3 +164,32 @@ as if they were contamination-free.
 
 Never label a task with provenance you can't stand behind, the benchmark's value
 is its transparency.
+
+
+## Multi-service environments (`metadata.environment`)
+
+A task that needs live services (databases, caches, load generators) ships a
+compose file and declares:
+
+```json
+"environment": {
+  "compose": "compose.yaml",
+  "ready": [{"service": "redis", "cmd": "redis-cli ping", "timeout_s": 60}],
+  "up_timeout_s": 300
+}
+```
+
+Rules the validator enforces:
+
+- publish ports **ephemerally** (`ports: ["6379"]`) — never `"6379:6379"`;
+  the harness resolves the real host ports per run,
+- no `container_name:` — per-run compose projects must not collide,
+- every `ready` probe needs `service` and `cmd` (run via `docker compose
+  exec` until it exits 0).
+
+The harness writes `.vb_services.json` (project name + `{service: {container
+port: host port}}`) into the workspace and gitignores it; the issue text
+should tell the agent to read it, and hidden tests reach services the same
+way. Environment tasks run with `--sandbox local` (the docker sandbox is
+network-disabled) and validate with `--sandbox local` plus host toolchains.
+Template: [`tasks/cii-v2/demo-compose-redis-smoke`](../tasks/cii-v2/demo-compose-redis-smoke).

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -41,6 +41,7 @@ from harness.agent.providers import LLMProvider, get_provider, parse_model_spec,
 from harness.agent.run_audit import audit_run
 from harness.economics import api_receipt, subscription_receipt
 from harness.effort import effort_config
+from harness.environment import start_environment
 from harness.evaluator.evaluate import evaluate_run
 from harness.evaluator.scorer import run_verifier, score_run
 from harness.persistence import maybe_post_run_summary
@@ -129,7 +130,7 @@ class _RunDeadline:
         collector.record("budget_exceeded", payload)
 
 
-def run_agent(
+def run_agent(  # noqa: PLR0915
     task_id: str,
     model: str,
     output_dir: Path = Path("./runs"),
@@ -180,6 +181,14 @@ def run_agent(
     # that declares a metadata "setup" key.
     _run_task_setup(task, workspace, executor, collector)
 
+    # Multi-service environments (metadata "environment") also come up before
+    # the clock starts; teardown is in the finally below.
+    environment = start_environment(task, run_id, workspace, sandbox=sandbox)
+    if environment is not None:
+        collector.record(
+            "environment_up", {"project": environment.project, "services": environment.ports}
+        )
+
     started_at = datetime.now(UTC)
     started_mono = time.monotonic()
     deadline = _RunDeadline(started_mono=started_mono, timeout_s=effective_timeout)
@@ -223,7 +232,9 @@ def run_agent(
         )
     finally:
         # Quality/security/judges run host-side over the mounted workspace and
-        # don't need the container, so tear it down now.
+        # don't need the container or the service stack, so tear both down now.
+        if environment is not None:
+            environment.down()
         close = getattr(executor, "close", None)
         if callable(close):
             close()

--- a/harness/environment.py
+++ b/harness/environment.py
@@ -1,0 +1,221 @@
+"""Multi-service docker-compose environments for tasks (CII v2 Phase 2).
+
+A task opts in through metadata:
+
+    "environment": {
+      "compose": "compose.yaml",
+      "ready": [
+        {"service": "redis", "cmd": "redis-cli ping", "timeout_s": 60}
+      ],
+      "up_timeout_s": 300
+    }
+
+``compose`` is resolved relative to the task directory. Before the agent's
+wall-clock budget starts, the harness brings the stack up under a unique
+per-run project name, polls every ``ready`` probe via ``docker compose exec``,
+resolves the *published* host ports, and writes ``.vb_services.json`` into the
+workspace (gitignored, so it never appears in ``final.patch``)::
+
+    {
+      "project": "vb-a1b2c3",
+      "services": {"redis": {"6379": 55123}}
+    }
+
+The agent and the hidden tests read that file to reach the services on
+``127.0.0.1``. Compose files must publish ports ephemerally (``ports:
+["6379"]``, never ``"6379:6379"``) so concurrent runs cannot collide; the
+per-run project name isolates networks, containers, and volumes. Teardown
+(``down -v --remove-orphans``) always runs, including on exceptions.
+
+Environment tasks currently require ``--sandbox local``: the docker sandbox
+runs agents with networking disabled, so in-container agents cannot reach the
+service stack. :func:`start_environment` enforces this.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from harness.sandbox.docker_executor import SandboxError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from harness.tasks import Task
+
+MANIFEST_NAME = ".vb_services.json"
+DEFAULT_UP_TIMEOUT_S = 300
+DEFAULT_READY_TIMEOUT_S = 60
+_READY_POLL_INTERVAL_S = 1.0
+
+
+def environment_spec(metadata: dict[str, Any]) -> dict[str, Any] | None:
+    """The task's ``environment`` object, or None when the task declares none."""
+    spec = metadata.get("environment")
+    return spec if isinstance(spec, dict) and spec.get("compose") else None
+
+
+class TaskEnvironment:
+    """Lifecycle manager for one run's compose stack.
+
+    Use as a context manager, or call :meth:`up` / :meth:`down` explicitly.
+    ``down`` is idempotent and safe to call from ``finally`` blocks.
+    """
+
+    def __init__(self, compose_file: Path, project: str, spec: dict[str, Any]):
+        self.compose_file = compose_file
+        self.project = project
+        self.spec = spec
+        self.ports: dict[str, dict[str, int]] = {}
+        self._up = False
+
+    # -- docker compose plumbing -------------------------------------------
+
+    def _compose(
+        self, *args: str, timeout: int, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        cmd = [
+            "docker",
+            "compose",
+            "-p",
+            self.project,
+            "-f",
+            str(self.compose_file),
+            *args,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+        if check and proc.returncode != 0:
+            raise SandboxError(
+                f"docker compose {' '.join(args[:2])} failed for project {self.project}: "
+                f"{proc.stderr.strip()[:500]}"
+            )
+        return proc
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def up(self) -> None:
+        timeout = int(self.spec.get("up_timeout_s") or DEFAULT_UP_TIMEOUT_S)
+        try:
+            self._compose("up", "-d", "--wait", timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            self.down()
+            raise SandboxError(
+                f"environment for project {self.project} did not come up within {timeout}s"
+            ) from exc
+        except SandboxError:
+            self.down()
+            raise
+        self._up = True
+        try:
+            self._wait_ready()
+            self._resolve_ports()
+        except Exception:
+            self.down()
+            raise
+
+    def _wait_ready(self) -> None:
+        for probe in self.spec.get("ready") or []:
+            service = str(probe.get("service") or "")
+            cmd = str(probe.get("cmd") or "")
+            if not service or not cmd:
+                raise SandboxError(f"malformed ready probe in environment spec: {probe!r}")
+            timeout = int(probe.get("timeout_s") or DEFAULT_READY_TIMEOUT_S)
+            deadline = time.monotonic() + timeout
+            last_err = ""
+            while time.monotonic() < deadline:
+                proc = self._compose(
+                    "exec", "-T", service, "sh", "-c", cmd, timeout=30, check=False
+                )
+                if proc.returncode == 0:
+                    break
+                last_err = (proc.stderr or proc.stdout or "").strip()[:200]
+                time.sleep(_READY_POLL_INTERVAL_S)
+            else:
+                raise SandboxError(
+                    f"service {service!r} not ready within {timeout}s "
+                    f"(probe {cmd!r}; last output: {last_err})"
+                )
+
+    def _resolve_ports(self) -> None:
+        proc = self._compose("ps", "--format", "json", timeout=30)
+        self.ports = {}
+        for raw_line in proc.stdout.splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except ValueError:
+                continue
+            service = row.get("Service")
+            if not service:
+                continue
+            published: dict[str, int] = {}
+            for pub in row.get("Publishers") or []:
+                target, host_port = pub.get("TargetPort"), pub.get("PublishedPort")
+                if target and host_port:
+                    published[str(target)] = int(host_port)
+            if published:
+                self.ports[service] = published
+
+    def write_manifest(self, workspace: Path) -> Path:
+        """Write ``.vb_services.json`` into the workspace and gitignore it."""
+        manifest = workspace / MANIFEST_NAME
+        manifest.write_text(
+            json.dumps({"project": self.project, "services": self.ports}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        gitignore = workspace / ".gitignore"
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+        if MANIFEST_NAME not in existing:
+            joiner = "" if not existing or existing.endswith("\n") else "\n"
+            gitignore.write_text(existing + joiner + MANIFEST_NAME + "\n", encoding="utf-8")
+        return manifest
+
+    def down(self) -> None:
+        with contextlib.suppress(subprocess.TimeoutExpired, OSError):  # best effort
+            self._compose("down", "-v", "--remove-orphans", "-t", "10", timeout=120, check=False)
+        self._up = False
+
+    def __enter__(self) -> TaskEnvironment:
+        self.up()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.down()
+
+
+def start_environment(
+    task: Task, run_token: str, workspace: Path, sandbox: str = "local"
+) -> TaskEnvironment | None:
+    """Bring up the task's environment, if it declares one.
+
+    Returns None for tasks without an ``environment`` block. Raises
+    :class:`SandboxError` when the stack cannot come up, when compose is
+    unavailable, or when the run uses the network-disabled docker sandbox.
+    """
+    spec = environment_spec(task.metadata)
+    if spec is None:
+        return None
+    if sandbox == "docker":
+        raise SandboxError(
+            "this task declares a multi-service environment, which requires "
+            "--sandbox local (the docker sandbox runs agents without networking)"
+        )
+    compose_file = (task.root / str(spec["compose"])).resolve()
+    if not compose_file.is_file():
+        raise SandboxError(f"environment compose file not found: {compose_file}")
+    probe = subprocess.run(
+        ["docker", "compose", "version"], capture_output=True, text=True, check=False
+    )
+    if probe.returncode != 0:
+        raise SandboxError("docker compose is not available on this host")
+    # Project names must be lowercase alphanumerics/dashes and unique per run.
+    project = f"vb-{run_token.lower().replace('_', '-')[-40:]}"
+    env = TaskEnvironment(compose_file, project, spec)
+    env.up()
+    env.write_manifest(workspace)
+    return env

--- a/harness/task_metadata.py
+++ b/harness/task_metadata.py
@@ -314,7 +314,59 @@ def validate_scale_fields(task_root: Path, metadata: dict[str, Any]) -> list[str
         reasons.append("test_timeout_s must be a positive number when set")
 
     reasons.extend(_validate_explicit_budgets(task_root, metadata))
+    reasons.extend(_validate_environment(task_root, metadata))
 
+    return reasons
+
+
+def _validate_environment(task_root: Path, metadata: dict[str, Any]) -> list[str]:
+    """Validate the optional multi-service ``environment`` block.
+
+    Checks that the compose file exists inside the task dir, that ready probes
+    are well-formed, and that the compose file avoids the two footguns that
+    break run isolation: fixed host-port publishing ("8080:80") and
+    ``container_name:`` (both collide across concurrent per-run projects).
+    """
+    spec = metadata.get("environment")
+    if spec is None:
+        return []
+    reasons: list[str] = []
+    if not isinstance(spec, dict) or not isinstance(spec.get("compose"), str):
+        return ["environment must be an object with a string 'compose' path"]
+    compose = (task_root / spec["compose"]).resolve()
+    try:
+        compose.relative_to(task_root.resolve())
+    except ValueError:
+        return [f"environment.compose must live inside the task dir: {spec['compose']}"]
+    if not compose.is_file():
+        return [f"environment.compose file not found: {spec['compose']}"]
+    text = compose.read_text(encoding="utf-8", errors="replace")
+    if re.search(r"^\s*container_name\s*:", text, re.M):
+        reasons.append(
+            "environment compose file must not set container_name (collides across runs)"
+        )
+    if re.search(r"-\s*[\"']?\d+:\d+", text):
+        reasons.append(
+            "environment compose file must publish ports ephemerally "
+            '(ports: ["6379"]), never with fixed host ports ("6379:6379")'
+        )
+    ready = spec.get("ready")
+    if ready is not None:
+        if not isinstance(ready, list):
+            reasons.append("environment.ready must be a list of {service, cmd} probes")
+        else:
+            for probe in ready:
+                if (
+                    not isinstance(probe, dict)
+                    or not isinstance(probe.get("service"), str)
+                    or not isinstance(probe.get("cmd"), str)
+                ):
+                    reasons.append(f"malformed environment.ready probe: {probe!r}")
+    up_timeout = spec.get("up_timeout_s")
+    if up_timeout is not None and (
+        not isinstance(up_timeout, (int, float)) or isinstance(up_timeout, bool) or up_timeout <= 0
+    ):
+        reasons.append("environment.up_timeout_s must be a positive number when set")
     return reasons
 
 

--- a/harness/tasks.py
+++ b/harness/tasks.py
@@ -149,6 +149,13 @@ def task_hash(task: Task) -> str:
         h.update(b"\0")
     h.update(b"issue\0")
     h.update(task.issue.encode())
+    env_spec = task.metadata.get("environment")
+    if isinstance(env_spec, dict) and isinstance(env_spec.get("compose"), str):
+        compose = task.root / env_spec["compose"]
+        if compose.is_file():
+            h.update(b"environment\0")
+            h.update(compose.read_bytes())
+            h.update(b"\0")
     if task.hidden_tests_dir is not None:
         _hash_dir(h, "tests", task.hidden_tests_dir)
     h.update(b"\0tests_spec\0")

--- a/harness/validate.py
+++ b/harness/validate.py
@@ -29,10 +29,12 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from harness.environment import start_environment
 from harness.sandbox.docker_executor import DockerToolExecutor
 from harness.sandbox.images import resolve_sandbox_image
 from harness.spec_check import WARN as _SPEC_WARN
@@ -177,7 +179,11 @@ def _fresh(
     runner: Runner | None = None
     if opts.sandbox == "docker":
         runner, executor = _docker_runner(task, ws, opts.image)
+    environment = None
     try:
+        environment = start_environment(
+            task, f"val-{name}-{uuid.uuid4().hex[:6]}", ws, sandbox=opts.sandbox
+        )
         if task.setup_commands:
             run_setup(task, ws, runner=runner)
         if apply_gold:
@@ -186,6 +192,8 @@ def _fresh(
                 raise RuntimeError("gold patch did not apply cleanly (git apply failed)")
         return _functional(task, ws, runner=runner)
     finally:
+        if environment is not None:
+            environment.down()
         if executor is not None:
             executor.close()
 

--- a/tasks/cii-v2/demo-compose-redis-smoke/compose.yaml
+++ b/tasks/cii-v2/demo-compose-redis-smoke/compose.yaml
@@ -1,0 +1,9 @@
+# Demo environment: a single Redis service with an ephemeral published port.
+# Template rules for environment tasks: no container_name, no fixed host
+# ports — the harness assigns a unique project per run and resolves the
+# published port into the workspace's .vb_services.json.
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379"

--- a/tasks/cii-v2/demo-compose-redis-smoke/gold_patch.diff
+++ b/tasks/cii-v2/demo-compose-redis-smoke/gold_patch.diff
@@ -1,0 +1,13 @@
+diff --git a/app.py b/app.py
+index 16d9126..3bc6ba9 100644
+--- a/app.py
++++ b/app.py
+@@ -6,7 +6,7 @@ from pathlib import Path
+ 
+ 
+ def flag_value() -> str:
+-    return "wrong-value"
++    return "expected-42"
+ 
+ 
+ def redis_port() -> int:

--- a/tasks/cii-v2/demo-compose-redis-smoke/issue.md
+++ b/tasks/cii-v2/demo-compose-redis-smoke/issue.md
@@ -1,0 +1,5 @@
+# Publish the expected flag value
+
+`app.publish_flag()` round-trips a flag through the run's Redis service
+(see `.vb_services.json` for the published port). The consumer expects the
+flag value to be exactly `expected-42`; it currently is not.

--- a/tasks/cii-v2/demo-compose-redis-smoke/metadata.json
+++ b/tasks/cii-v2/demo-compose-redis-smoke/metadata.json
@@ -1,0 +1,30 @@
+{
+  "id": "demo-compose-redis-smoke",
+  "category": "demo",
+  "languages": ["python"],
+  "difficulty": "trivial",
+  "task_complexity": "localized",
+  "created": "2026-08-24",
+  "repo_scale": "micro",
+  "source": "hand-authored",
+  "decontaminated": true,
+  "decontamination_notes": "Hand-authored walking-skeleton demo for the multi-service environment feature (CII v2 Phase 2). Exists to exercise and document the environment lifecycle end to end: compose up with a unique per-run project, readiness probing, ephemeral published-port resolution into .vb_services.json, verifier connectivity from the host to the service, and deterministic x3 teardown/reup. Not a benchmark task; never add it to a measured suite. It doubles as the template for authoring real environment tasks: note the compose rules (no container_name, no fixed host ports) and the manifest-reading pattern in repo/app.py.",
+  "environment": {
+    "compose": "compose.yaml",
+    "ready": [
+      {"service": "redis", "cmd": "redis-cli ping", "timeout_s": 60}
+    ]
+  },
+  "grader": "tests",
+  "tests": {
+    "fail_to_pass": [
+      {"name": "flag_round_trip", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider oss_tests.py -q"}
+    ],
+    "pass_to_pass": [
+      {"name": "manifest", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider reg_tests.py::test_manifest_present_with_project -q"},
+      {"name": "redis_ping", "cmd": "PYTHONPATH=. python -m pytest -c /dev/null -p no:cacheprovider reg_tests.py::test_redis_answers_ping -q"}
+    ]
+  },
+  "test_timeout_s": 120,
+  "agent_hints": {"suggested_max_steps": 50, "suggested_timeout_s": 300}
+}

--- a/tasks/cii-v2/demo-compose-redis-smoke/repo/app.py
+++ b/tasks/cii-v2/demo-compose-redis-smoke/repo/app.py
@@ -1,0 +1,27 @@
+"""Demo app: publishes a flag value into the run's Redis service."""
+
+import json
+import socket
+from pathlib import Path
+
+
+def flag_value() -> str:
+    return "wrong-value"
+
+
+def redis_port() -> int:
+    manifest = json.loads(Path(".vb_services.json").read_text())
+    return int(manifest["services"]["redis"]["6379"])
+
+
+def _resp(sock: socket.socket, *parts: str) -> str:
+    payload = f"*{len(parts)}\r\n" + "".join(f"${len(p)}\r\n{p}\r\n" for p in parts)
+    sock.sendall(payload.encode())
+    return sock.recv(4096).decode()
+
+
+def publish_flag() -> str:
+    with socket.create_connection(("127.0.0.1", redis_port()), timeout=5) as s:
+        _resp(s, "SET", "vb:flag", flag_value())
+        reply = _resp(s, "GET", "vb:flag")
+    return reply.split("\r\n")[1]

--- a/tasks/cii-v2/demo-compose-redis-smoke/tests/oss_tests.py
+++ b/tasks/cii-v2/demo-compose-redis-smoke/tests/oss_tests.py
@@ -1,0 +1,7 @@
+"""Hidden fail-to-pass: the flag round-tripped through Redis must be correct."""
+
+import app
+
+
+def test_flag_round_trips_with_expected_value():
+    assert app.publish_flag() == "expected-42"

--- a/tasks/cii-v2/demo-compose-redis-smoke/tests/reg_tests.py
+++ b/tasks/cii-v2/demo-compose-redis-smoke/tests/reg_tests.py
@@ -1,0 +1,19 @@
+"""Hidden guards: the service stack itself is reachable and manifest sane."""
+
+import json
+import socket
+from pathlib import Path
+
+import app
+
+
+def test_manifest_present_with_project():
+    manifest = json.loads(Path(".vb_services.json").read_text())
+    assert manifest["project"].startswith("vb-")
+    assert "redis" in manifest["services"]
+
+
+def test_redis_answers_ping():
+    with socket.create_connection(("127.0.0.1", app.redis_port()), timeout=5) as s:
+        s.sendall(b"*1\r\n$4\r\nPING\r\n")
+        assert s.recv(64).startswith(b"+PONG")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,98 @@
+"""Tests for multi-service docker-compose task environments."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+import pytest
+
+from harness.environment import TaskEnvironment, environment_spec, start_environment
+from harness.sandbox.docker_executor import SandboxError
+from harness.task_metadata import _validate_environment
+from harness.tasks import load_task
+
+DEMO_ROOT = Path(__file__).resolve().parents[1] / "tasks" / "cii-v2"
+DEMO_ID = "demo-compose-redis-smoke"
+
+
+def test_environment_spec_parsing():
+    assert environment_spec({}) is None
+    assert environment_spec({"environment": {}}) is None
+    assert environment_spec({"environment": {"compose": "c.yaml"}}) == {"compose": "c.yaml"}
+
+
+def test_validate_environment_rejects_footguns(tmp_path: Path):
+    (tmp_path / "compose.yaml").write_text(
+        'services:\n  db:\n    image: redis\n    container_name: fixed\n    ports:\n      - "6379:6379"\n'
+    )
+    reasons = _validate_environment(
+        tmp_path, {"environment": {"compose": "compose.yaml", "ready": [{"service": "db"}]}}
+    )
+    text = " ".join(reasons)
+    assert "container_name" in text
+    assert "ephemerally" in text
+    assert "malformed" in text
+
+
+def test_validate_environment_accepts_clean_spec(tmp_path: Path):
+    (tmp_path / "compose.yaml").write_text(
+        'services:\n  db:\n    image: redis\n    ports:\n      - "6379"\n'
+    )
+    spec = {
+        "environment": {
+            "compose": "compose.yaml",
+            "ready": [{"service": "db", "cmd": "true"}],
+            "up_timeout_s": 60,
+        }
+    }
+    assert _validate_environment(tmp_path, spec) == []
+
+
+def test_validate_environment_missing_file(tmp_path: Path):
+    reasons = _validate_environment(tmp_path, {"environment": {"compose": "nope.yaml"}})
+    assert reasons and "not found" in reasons[0]
+
+
+def test_start_environment_none_without_spec(tmp_path: Path):
+    task = load_task(DEMO_ID, DEMO_ROOT)
+    task.metadata.pop("environment")
+    assert start_environment(task, "t", tmp_path) is None
+
+
+def test_start_environment_rejects_docker_sandbox(tmp_path: Path):
+    task = load_task(DEMO_ID, DEMO_ROOT)
+    with pytest.raises(SandboxError, match="sandbox local"):
+        start_environment(task, "t", tmp_path, sandbox="docker")
+
+
+@pytest.mark.docker
+def test_environment_full_lifecycle(tmp_path: Path):
+    task = load_task(DEMO_ID, DEMO_ROOT)
+    env = start_environment(task, "pytest-lifecycle", tmp_path)
+    assert env is not None
+    try:
+        assert env.project.startswith("vb-")
+        assert "redis" in env.ports and "6379" in env.ports["redis"]
+        manifest = json.loads((tmp_path / ".vb_services.json").read_text())
+        assert manifest["project"] == env.project
+        assert (tmp_path / ".gitignore").read_text().count(".vb_services.json") == 1
+        # ready probe already ran; the port answers PING
+        with socket.create_connection(("127.0.0.1", env.ports["redis"]["6379"]), timeout=5) as s:
+            s.sendall(b"*1\r\n$4\r\nPING\r\n")
+            assert s.recv(64).startswith(b"+PONG")
+    finally:
+        env.down()
+    # down is idempotent
+    env.down()
+
+
+@pytest.mark.docker
+def test_environment_up_failure_is_sandbox_error(tmp_path: Path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("services:\n  x:\n    image: vulcanbench/definitely-not-an-image:zzz\n")
+    env = TaskEnvironment(bad, "vb-pytest-badimage", {"up_timeout_s": 30})
+    with pytest.raises(SandboxError):
+        env.up()
+    env.down()


### PR DESCRIPTION
The harness unlock for the 50–70 plan: tasks can now declare live service stacks.

## What a task declares
```json
"environment": {
  "compose": "compose.yaml",
  "ready": [{"service": "redis", "cmd": "redis-cli ping"}]
}
```

## What the harness does
- **Before the agent's clock starts**: `compose up -d --wait` under a unique per-run project, readiness probes via `compose exec`, ephemeral published ports resolved into a gitignored `.vb_services.json` the agent and hidden tests read.
- **Always**: `down -v --remove-orphans` teardown, including on partial startup failure and exceptions — wired into both `vulcanbench run` and validation (fresh stack per gold/base/determinism run).
- **Validator-enforced isolation**: no `container_name`, no fixed host ports, well-formed probes; `task_hash` covers the compose file. Environment tasks require `--sandbox local` (enforced with a clear error — the docker sandbox is network-disabled).

## Proof of life
`tasks/cii-v2/demo-compose-redis-smoke` (the authoring template): **gold=1.0, pre-patch=0.0, deterministic ×3** — each of the four validation runs on its own fresh Redis stack, graded through the live service via raw RESP, zero leftover containers. A mock-model `vulcanbench run` exercised the run path the same way (guards passed against live Redis).

Tests: 6 unit + 2 docker-marked integration; suite green under the CI selection; mypy + ruff clean.

Next: author the first real environment task (migration-under-live-load / incident-response class) and gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)