### PR TITLE
Block system pip installs from host-run CLI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Host-run CLI agents can no longer pip-install into the system Python.**
+  `_subscription_env()` now sets `PIP_REQUIRE_VIRTUALENV=1` and
+  `PYTHONNOUSERSITE=1` for every subscription CLI subprocess (claude-code,
+  codex, cursor, grok-build, zcode). A live ZCode run on
+  `oss-aiohttp-upgrade-deferred` ran `pip install -e .` in its host workspace,
+  hit Homebrew's python3.14, and left a dangling editable aiohttp that broke
+  the host `pytest` once the temp workspace was cleaned. Agents that need pip
+  must now create their own virtualenv inside the workspace.
 - **xAI reasoning tokens are now billed.** xAI reports reasoning OUTSIDE
   `completion_tokens` (total = prompt + completion + reasoning), unlike
   OpenAI/DeepSeek/Qwen/Kimi where completion contains it. The Chat Completions

--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -230,6 +230,15 @@ def _subscription_env(extra: dict[str, str] | None = None) -> dict[str, str]:
             p for p in env["PATH"].split(os.pathsep) if p and not p.startswith(repo_root)
         )
     env["DISABLE_AUTOUPDATER"] = "1"
+    # Host-run agents must not touch the system Python. A live ZCode run on
+    # oss-aiohttp-upgrade-deferred (Aug 2026) ran `pip install -e .` in its
+    # workspace, hit Homebrew's python3.14, and left a dangling editable
+    # install that broke the host pytest once the workspace was cleaned.
+    # PIP_REQUIRE_VIRTUALENV makes pip refuse any install outside a venv the
+    # agent creates itself; PYTHONNOUSERSITE keeps user site-packages out of
+    # reach as the fallback target.
+    env["PIP_REQUIRE_VIRTUALENV"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
     if extra:
         env.update(extra)
     return env

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -20,6 +20,7 @@ from harness.agent import loop as loop_mod
 from harness.agent.cli_agents import (
     _ZCODE_LIMIT_PATTERN,
     SubscriptionQuotaError,
+    _subscription_env,
     _zcode_preflight,
     _zcode_session_limit_error,
     is_cli_agent_spec,
@@ -1028,3 +1029,16 @@ def test_codex_judge_provider_single_shot(
     # 120 input with 80 cached folds to (120-80) + 80*0.1 = 48 effective.
     assert response.usage.prompt_tokens == 48
     assert response.usage.completion_tokens == 30
+
+
+def test_subscription_env_blocks_system_pip_installs() -> None:
+    """Host-run agents must not be able to pip-install into the system Python.
+
+    A live ZCode run on oss-aiohttp-upgrade-deferred installed an editable
+    aiohttp into Homebrew's python3.14 and broke the host pytest.
+    """
+    env = _subscription_env()
+    assert env["PIP_REQUIRE_VIRTUALENV"] == "1"
+    assert env["PYTHONNOUSERSITE"] == "1"
+    # Test adapters may still override explicitly.
+    assert _subscription_env({"PIP_REQUIRE_VIRTUALENV": "0"})["PIP_REQUIRE_VIRTUALENV"] == "0"


### PR DESCRIPTION
`_subscription_env()` now sets `PIP_REQUIRE_VIRTUALENV=1` and `PYTHONNOUSERSITE=1` for every subscription CLI subprocess (claude-code, codex, cursor, grok-build, zcode).

Why: during the GLM 5.3 sweeps, the ZCode run on `oss-aiohttp-upgrade-deferred` ran `pip install -e .` in its host tempdir workspace, pip resolved to Homebrew's python3.14, and the resulting editable aiohttp went dangling when the workspace was cleaned, breaking the host `pytest` (the source of the 8 spurious test failures diagnosed on 2026-08-24).

With the guard, pip refuses installs outside a virtualenv the agent creates itself, and user site-packages are out of reach as a fallback. Test adapters can still override via the `extra` mapping; a unit test covers both.

ruff, mypy, no-em-dash check, and the full cli-agent test file are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)