### PR TITLE
[BUG] Neutralize repo-root pytest `--cov` addopts leak in the declarative functional grader (mis-scores every task 0.0) - fix + closing #79

### DIFF
--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -985,7 +985,7 @@ def _execute_tool(
         observation = _run_command_tool(
             executor,
             RunCommandArgs(
-                cmd="python -m pytest -q --tb=no || true", timeout=_tool_timeout(timeout_s)
+                cmd="python -m pytest -q --tb=no -o addopts= || true", timeout=_tool_timeout(timeout_s)
             ),
         )
     elif tc.name == "run_lint":

--- a/harness/agent/test_commands.py
+++ b/harness/agent/test_commands.py
@@ -22,4 +22,6 @@ def default_test_command(workspace: Path) -> str:
         )
     if (ws / "pom.xml").exists() or (ws / "build.gradle").exists():
         return "mvn -q test 2>&1 || ./gradlew test 2>&1 || true"
-    return "python -m pytest -q --tb=no 2>&1 || true"
+    # `-o addopts=` neutralizes the repo-root pyproject.toml --cov= addopts that
+    # pytest inherits when running inside a workspace under runs/ (would error the run).
+    return "python -m pytest -q --tb=no -o addopts= 2>&1 || true"

--- a/harness/verifier.py
+++ b/harness/verifier.py
@@ -87,6 +87,18 @@ def _infrastructure_reason(cmd: str, outcome: RunnerOutcome) -> str | None:
     return None
 
 
+
+def _normalize_test_cmd(cmd: str) -> str:
+    # Neutralize the repo-root pyproject.toml `addopts = --cov=...` leak.
+    # pytest auto-discovers the inifile up from the workspace, so running under
+    # `runs/<task>-*/workspace` resolves rootdir to the VulcanBench repo root and
+    # inherits `--cov=harness --cov-report=... --cov-fail-under=...`. Those flags
+    # make pytest error before running any test, so functionally-correct patches
+    # are scored 0.0. Appending `-o addopts=` clears the inherited addopts so the
+    # gold tests actually run.
+    if "pytest" in cmd and "-o addopts" not in cmd: return cmd + " -o addopts="
+    return cmd
+
 def _run_group(
     entries: list[dict[str, Any]], workspace: Path, timeout: int, runner: Runner
 ) -> dict[str, bool]:
@@ -97,7 +109,7 @@ def _run_group(
         if not cmd:
             results[name] = False
             continue
-        raw_outcome = runner(str(cmd), workspace, timeout)
+        raw_outcome = runner(_normalize_test_cmd(str(cmd)), workspace, timeout)
         outcome = (
             raw_outcome
             if isinstance(raw_outcome, RunnerOutcome)


### PR DESCRIPTION
## Fix: neutralize pytest cov-coverage addopts leakage in the functional grader

Closes #79

### Problem
Repo-root `pyproject.toml` sets pytest `addopts = --cov=harness --cov-report=term-missing:skip-covered --cov-fail-under=80`. When the declarative functional grader runs `python -m pytest <hidden_tests>` in a workspace under `runs/`, pytest's `rootdir` resolves to the VulcanBench repo root, so it inherits this `addopts`. `--cov=harness` then collects 0% on the harness module (the hidden tests import `dag/ratecache`, not `harness`), the 80% coverage gate fails, pytest exits non-zero, and **every functionally-correct patch is scored `functional=0.0`**. This hit ALL declarative Python tasks (py-topo-sort-cycle, py-semver-compare, py-ttl-cache-expiry) across BOTH deepseek-chat and deepseek-v4-pro — a false FAIL that is a harness bug, not a model failure.

### Proof
All 29 hidden tests across the 3 'failed' tasks pass 100% with `-o addopts=` (coverage-neutralized) against the same saved workspaces.

### Fix
Append `-o addopts=` to every pytest command the grader emits (`harness/verifier.py._normalize_test_cmd`, and the agent `run_tests`/`test_commands.py` paths). This is a no-op when no harmful addopts exist, and it neutralizes the leak when they do.

### Why I removed the PR I'd intended
The fix is deliberately surgical: don't touch `pyproject.toml` (coverage is a dev-tool concern); just make the harness tests hermetic against inherited config.

Benchmark results backing this: on tasks/v2 realistic-hard, deepseek-v4-flash passes all 10/10 once the grading is correct (was mis-scored via this bug). Full write-up in the issue.
