### PR TITLE
Add floor/ceiling sandbox resource bands and OOM infra-error classification

### DIFF
--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -49,6 +49,7 @@ from harness.pricing import cost_usd, has_cached_input_price, is_priced
 from harness.redaction import sanitize
 from harness.sandbox.docker_executor import (
     DockerToolExecutor,
+    ResourceSpec,
     SandboxError,
     _docker_available,
 )
@@ -64,7 +65,13 @@ from harness.task_metadata import (
 )
 from harness.tasks import Task, load_task, prepare_workspace, run_setup, task_hash
 from harness.tracer.collector import TraceCollector, generate_replay_html
-from harness.verifier import DEFAULT_TIMEOUT, Runner, RunnerOutcome, run_declarative_verifier
+from harness.verifier import (
+    DEFAULT_TIMEOUT,
+    Runner,
+    RunnerOutcome,
+    VerifierInfrastructureError,
+    run_declarative_verifier,
+)
 
 SYSTEM_PROMPT = (
     "You are an autonomous software engineering agent. Solve the task described "
@@ -149,6 +156,7 @@ def run_agent(  # noqa: PLR0915
     experiment_id: str | None = None,
     max_run_cost: float | None = None,
     override_budgets: bool = False,
+    resources: ResourceSpec | None = None,
 ) -> dict[str, Any]:
     """Run one evaluation: agent solves ``task_id`` with ``model``.
 
@@ -174,7 +182,7 @@ def run_agent(  # noqa: PLR0915
     agent_tmp_root, workspace = _resolve_workspace(cli_adapter, run_id, run_dir)
     prepare_workspace(task, workspace)
     _git_init(workspace)
-    executor = _make_executor(sandbox, workspace, image, network, task, collector)
+    executor = _make_executor(sandbox, workspace, image, network, task, collector, resources)
 
     # Run setup commands BEFORE the agent's wall-clock budget starts.
     # This is used by Rust tasks (cargo build --tests warm-up) and any task
@@ -839,9 +847,17 @@ def _collect_manifest(
             "mode": sandbox_mode,
             "image": getattr(executor, "image", None),
             "network": network,
+            "resources": _resource_disclosure(executor),
+            "oom_kills": getattr(executor, "oom_kill_count", None),
         },
         "tools": tools,
     } | _route_entry(model)
+
+
+def _resource_disclosure(executor: ToolProtocol) -> dict[str, Any] | None:
+    """The container resource band, or None for host execution (uncapped)."""
+    resources = getattr(executor, "resources", None)
+    return resources.to_dict() if isinstance(resources, ResourceSpec) else None
 
 
 def _minimal_manifest(
@@ -861,6 +877,8 @@ def _minimal_manifest(
             "mode": sandbox_mode,
             "image": getattr(executor, "image", None),
             "network": network,
+            "resources": _resource_disclosure(executor),
+            "oom_kills": getattr(executor, "oom_kill_count", None),
         },
         "tools": {tool: None for tool in _MANIFEST_TOOLS},
     } | _route_entry(model)
@@ -891,6 +909,7 @@ def _make_executor(
     network: bool,
     task: Task,
     collector: TraceCollector,
+    resources: ResourceSpec | None = None,
 ) -> ToolProtocol:
     """Build the tool executor for the requested sandbox mode.
 
@@ -904,14 +923,32 @@ def _make_executor(
         collector.record("sandbox", {"mode": "local"})
         return LocalToolExecutor(workspace)
     if sandbox == "docker":
-        collector.record("sandbox", {"mode": "docker", "image": resolved_image, "network": network})
-        return DockerToolExecutor(workspace, image=resolved_image, network=network)
+        collector.record(
+            "sandbox",
+            {
+                "mode": "docker",
+                "image": resolved_image,
+                "network": network,
+                "resources": (resources or ResourceSpec()).to_dict(),
+            },
+        )
+        return DockerToolExecutor(
+            workspace, image=resolved_image, network=network, resources=resources
+        )
     if sandbox == "auto":
         if _docker_available():
             collector.record(
-                "sandbox", {"mode": "docker", "image": resolved_image, "network": network}
+                "sandbox",
+                {
+                    "mode": "docker",
+                    "image": resolved_image,
+                    "network": network,
+                    "resources": (resources or ResourceSpec()).to_dict(),
+                },
             )
-            return DockerToolExecutor(workspace, image=resolved_image, network=network)
+            return DockerToolExecutor(
+                workspace, image=resolved_image, network=network, resources=resources
+            )
         if os.environ.get("VULCANBENCH_ALLOW_HOST_EXEC") != "1":
             raise SandboxError(
                 "sandbox 'auto': Docker daemon unavailable. Refusing to run "
@@ -1103,8 +1140,16 @@ def _executor_runner_outcome(executor: ToolProtocol, cmd: str, timeout: int) -> 
         res = executor.run_command(RunCommandArgs(cmd=cmd, timeout=timeout))
     except Exception as exc:
         return RunnerOutcome(124, stderr=str(exc))
+    exit_code = int(res.get("exit_code", 1))
+    if res.get("oom_killed") and isinstance(executor, DockerToolExecutor):
+        # The resource ceiling killed the verifier command. Scoring that
+        # against the model would attribute an infrastructure event to it.
+        raise VerifierInfrastructureError(
+            f"verifier command OOM-killed at the sandbox memory ceiling "
+            f"({executor.resources.mem_ceiling}): {cmd!r}"
+        )
     return RunnerOutcome(
-        int(res.get("exit_code", 1)),
+        exit_code,
         stdout=str(res.get("stdout") or res.get("result") or ""),
         stderr=str(res.get("stderr") or ""),
     )

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -34,7 +34,7 @@ from harness.leaderboard import aggregate_by_model, scan_leaderboard
 from harness.pricing import is_priced
 from harness.regrade import find_run_dirs, regrade_run
 from harness.report import build_report, to_markdown
-from harness.sandbox.docker_executor import SandboxError
+from harness.sandbox.docker_executor import ResourceSpec, SandboxError
 from harness.suite import SUITE_ALIASES, load_suite, run_suite
 from harness.tasks import list_task_ids
 from harness.validate import main as validate_main
@@ -226,6 +226,26 @@ def run(  # noqa: PLR0912, PLR0915, CLI entry: option declarations + linear guar
     network: bool = typer.Option(
         False, "--network/--no-network", help="Allow network in the docker sandbox"
     ),
+    mem_floor: str | None = typer.Option(
+        None,
+        "--mem-floor",
+        help="Guaranteed sandbox memory (docker mem_reservation, e.g. 2g). "
+        "Floor of the resource band; see the infrastructure-noise methodology.",
+    ),
+    mem_ceiling: str = typer.Option(
+        "2g",
+        "--mem-ceiling",
+        help="Hard sandbox memory kill threshold (docker mem_limit)",
+    ),
+    cpu_floor: float | None = typer.Option(
+        None,
+        "--cpu-floor",
+        help="Guaranteed sandbox CPUs under contention (docker cpu_shares weight)",
+    ),
+    cpu_ceiling: float = typer.Option(
+        2.0, "--cpu-ceiling", help="Hard sandbox CPU cap (docker nano_cpus)"
+    ),
+    pids_limit: int = typer.Option(512, "--pids-limit", help="Hard sandbox process-count cap"),
     repeat: int = typer.Option(1, "--repeat", help="Run each task N times (for pass@k / stderr)"),
     max_concurrency: int = typer.Option(
         1, "--max-concurrency", help="Run suite tasks in parallel (suite runs only)"
@@ -365,6 +385,13 @@ def run(  # noqa: PLR0912, PLR0915, CLI entry: option declarations + linear guar
         "effort": effort,
         "max_run_cost": max_run_cost,
         "override_budgets": override_budgets,
+        "resources": ResourceSpec(
+            mem_floor=mem_floor,
+            mem_ceiling=mem_ceiling,
+            cpu_floor=cpu_floor,
+            cpu_ceiling=cpu_ceiling,
+            pids_limit=pids_limit,
+        ),
     }
     pass_at_1: float | None = None
     n_incomplete = 0  # errored + skipped runs (an incomplete suite)

--- a/harness/sandbox/docker_executor.py
+++ b/harness/sandbox/docker_executor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import os
 import shlex
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,11 @@ DEFAULT_IMAGE = os.environ.get("VULCANBENCH_SANDBOX_IMAGE", "vulcanbench/sandbox
 
 _CONTAINER_WORKDIR = "/workspace"
 
+# Exit status of a SIGKILLed process (128 + 9): the signature of an OOM kill,
+# but also of any other KILL, so it is only classified together with the
+# cgroup's oom_kill counter.
+_SIGKILL_EXIT = 137
+
 # Writable paths for non-root containers (host UID/GID). Without these, `go test`
 # fails trying to create ~/.cache/go-build under `/` when HOME is unset.
 _SANDBOX_ENV = {
@@ -54,6 +60,32 @@ _SANDBOX_ENV = {
 
 class SandboxError(RuntimeError):
     """Raised when the sandbox container cannot be created or used."""
+
+
+@dataclass(frozen=True)
+class ResourceSpec:
+    """Floor/ceiling resource band for the sandbox container.
+
+    Follows the floor/ceiling separation from Anthropic's infrastructure-noise
+    methodology: the floor is a guaranteed allocation (Docker soft limits), the
+    ceiling is the hard kill threshold. A pinned single value makes transient
+    spikes read as task failures; a band absorbs them while keeping pressure.
+
+    Floors are best-effort on Docker: ``mem_floor`` maps to ``mem_reservation``
+    (enforced only under host memory pressure) and ``cpu_floor`` to a
+    ``cpu_shares`` weight (a relative guarantee under contention, not an
+    absolute reservation). Ceilings are hard: ``mem_ceiling`` -> ``mem_limit``
+    (OOM kill), ``cpu_ceiling`` -> ``nano_cpus`` (throttling), ``pids_limit``.
+    """
+
+    mem_floor: str | None = None
+    mem_ceiling: str = "2g"
+    cpu_floor: float | None = None
+    cpu_ceiling: float = 2.0
+    pids_limit: int = 512
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 def _decode(b: Any) -> str:
@@ -85,6 +117,7 @@ class DockerToolExecutor(ToolProtocol):
         cpus: float = 2.0,
         pids_limit: int = 512,
         default_timeout: int = 120,
+        resources: ResourceSpec | None = None,
     ) -> None:
         self.workspace = Path(workspace).resolve()
         self.workspace.mkdir(parents=True, exist_ok=True)
@@ -93,6 +126,13 @@ class DockerToolExecutor(ToolProtocol):
         self.image = image
         self.default_timeout = default_timeout
         self._closed = False
+        # ``resources`` wins over the legacy single-value kwargs; the legacy
+        # values become the ceiling of a floorless band, preserving behavior.
+        self.resources = resources or ResourceSpec(
+            mem_ceiling=mem_limit, cpu_ceiling=cpus, pids_limit=pids_limit
+        )
+        self.oom_kill_count = 0
+        self._oom_baseline: int | None = None
 
         try:
             self._client = docker.from_env()
@@ -109,6 +149,13 @@ class DockerToolExecutor(ToolProtocol):
         if hasattr(os, "getuid"):
             run_kwargs["user"] = f"{os.getuid()}:{os.getgid()}"
 
+        spec = self.resources
+        if spec.mem_floor is not None:
+            run_kwargs["mem_reservation"] = spec.mem_floor
+        if spec.cpu_floor is not None:
+            # cpu_shares is a relative weight (1024 == one default-weight
+            # container's worth); a floor of N cpus gets N shares of weight.
+            run_kwargs["cpu_shares"] = max(2, int(spec.cpu_floor * 1024))
         try:
             self._container = self._client.containers.run(
                 image,
@@ -118,9 +165,9 @@ class DockerToolExecutor(ToolProtocol):
                 volumes={str(self.workspace): {"bind": _CONTAINER_WORKDIR, "mode": "rw"}},
                 environment=_SANDBOX_ENV,
                 network_disabled=not network,
-                mem_limit=mem_limit,
-                nano_cpus=int(cpus * 1_000_000_000),
-                pids_limit=pids_limit,
+                mem_limit=spec.mem_ceiling,
+                nano_cpus=int(spec.cpu_ceiling * 1_000_000_000),
+                pids_limit=spec.pids_limit,
                 security_opt=["no-new-privileges"],
                 cap_drop=["ALL"],
                 tty=False,
@@ -177,11 +224,50 @@ class DockerToolExecutor(ToolProtocol):
             raise SandboxError(f"container exec failed: {e}") from e
         raw = result.output
         out_b, err_b = raw if isinstance(raw, tuple) else (raw, None)
-        return {
+        payload = {
             "stdout": _decode(out_b),
             "stderr": _decode(err_b),
             "exit_code": result.exit_code,
         }
+        if result.exit_code == _SIGKILL_EXIT:
+            # A 137 is only an OOM if the cgroup's kill counter moved; plain
+            # SIGKILLs (e.g. `timeout -s KILL`) must not count as infra noise.
+            new_kills = self._new_oom_kills()
+            self.oom_kill_count += new_kills
+            payload["oom_killed"] = new_kills > 0
+        return payload
+
+    # --- OOM accounting -------------------------------------------------------
+    def _read_oom_kills(self) -> int:
+        """Total OOM kills in the container's cgroup (v2 or v1), else 0."""
+        try:
+            result = self._container.exec_run(
+                [
+                    "sh",
+                    "-c",
+                    "cat /sys/fs/cgroup/memory.events "
+                    "/sys/fs/cgroup/memory/memory.oom_control 2>/dev/null || true",
+                ],
+                demux=True,
+            )
+        except Exception:
+            return 0
+        out_b = result.output[0] if isinstance(result.output, tuple) else result.output
+        kills = 0
+        for line in _decode(out_b).splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[0] == "oom_kill" and parts[1].isdigit():
+                kills = max(kills, int(parts[1]))
+        return kills
+
+    def _new_oom_kills(self) -> int:
+        """OOM kills since the previous check (first call sets the baseline)."""
+        current = self._read_oom_kills()
+        if self._oom_baseline is None:
+            self._oom_baseline = 0
+        new = max(0, current - self._oom_baseline)
+        self._oom_baseline = current
+        return new
 
     # --- lifecycle ------------------------------------------------------------
     def close(self) -> None:

--- a/tests/test_docker_executor.py
+++ b/tests/test_docker_executor.py
@@ -14,15 +14,17 @@ from typing import Any
 import docker
 import pytest
 
-from harness.agent.loop import _collect_manifest, _executor_runner
+from harness.agent.loop import _collect_manifest, _executor_runner, _executor_runner_outcome
 from harness.agent.protocol import EditFileArgs, ReadFileArgs, RunCommandArgs
 from harness.sandbox.docker_executor import (
     _SANDBOX_ENV,
     DEFAULT_IMAGE,
     DockerToolExecutor,
+    ResourceSpec,
     SandboxError,
     _docker_available,
 )
+from harness.verifier import VerifierInfrastructureError
 
 
 class FakeExecResult:
@@ -237,3 +239,87 @@ def test_live_run_command(tmp_path: Path) -> None:
         out = ex.run_command(RunCommandArgs(cmd="echo sandbox-ok"))
         assert out["exit_code"] == 0
         assert "sandbox-ok" in out["stdout"]
+
+
+# --- resource band (floor/ceiling) and OOM classification ---------------------
+
+
+def test_resource_spec_floor_ceiling_mapping(tmp_path: Path, fake_docker: FakeClient) -> None:
+    spec = ResourceSpec(
+        mem_floor="1g", mem_ceiling="4g", cpu_floor=1.0, cpu_ceiling=3.0, pids_limit=1024
+    )
+    ex = DockerToolExecutor(tmp_path, image="img", resources=spec)
+    kw = fake_docker.containers.run_kwargs
+    assert kw["mem_reservation"] == "1g"
+    assert kw["mem_limit"] == "4g"
+    assert kw["cpu_shares"] == 1024
+    assert kw["nano_cpus"] == 3_000_000_000
+    assert kw["pids_limit"] == 1024
+    assert ex.resources is spec
+    ex.close()
+
+
+def test_legacy_kwargs_become_floorless_band(tmp_path: Path, fake_docker: FakeClient) -> None:
+    ex = DockerToolExecutor(tmp_path, mem_limit="3g", cpus=1.5, pids_limit=256)
+    kw = fake_docker.containers.run_kwargs
+    assert kw["mem_limit"] == "3g"
+    assert kw["nano_cpus"] == 1_500_000_000
+    assert kw["pids_limit"] == 256
+    assert "mem_reservation" not in kw
+    assert "cpu_shares" not in kw
+    assert ex.resources == ResourceSpec(mem_ceiling="3g", cpu_ceiling=1.5, pids_limit=256)
+    ex.close()
+
+
+class OOMFakeContainer(FakeContainer):
+    """Returns SIGKILL exits for commands and a live oom_kill counter for reads."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.oom_kills = 0
+
+    def exec_run(self, cmd: Any, workdir: str | None = None, demux: bool = False) -> FakeExecResult:
+        self.exec_calls.append({"cmd": cmd, "workdir": workdir, "demux": demux})
+        shell = cmd[-1] if isinstance(cmd, list) else str(cmd)
+        if "memory.events" in shell:
+            return FakeExecResult(0, (f"low 0\noom 0\noom_kill {self.oom_kills}\n".encode(), b""))
+        return FakeExecResult(137, (b"", b"Killed\n"))
+
+
+def test_oom_kill_counted_only_when_counter_moves(tmp_path: Path, fake_docker: FakeClient) -> None:
+    container = OOMFakeContainer()
+    fake_docker.containers.container = container
+    ex = DockerToolExecutor(tmp_path, image="img")
+    # SIGKILL exit with a flat counter: a plain kill, not an OOM.
+    out = ex.run_command(RunCommandArgs(cmd="sleep 999"))
+    assert out["exit_code"] == 137
+    assert ex.oom_kill_count == 0
+    # Counter moves: the next 137 is attributed to the memory ceiling.
+    container.oom_kills = 1
+    ex.run_command(RunCommandArgs(cmd="hog-memory"))
+    assert ex.oom_kill_count == 1
+    ex.close()
+
+
+def test_verifier_oom_raises_infrastructure_error(
+    tmp_path: Path, fake_docker: FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    container = OOMFakeContainer()
+    fake_docker.containers.container = container
+    ex = DockerToolExecutor(tmp_path, image="img")
+    container.oom_kills = 2
+    with pytest.raises(VerifierInfrastructureError, match="OOM"):
+        _executor_runner_outcome(ex, "pytest -q", 120)
+    ex.close()
+
+
+def test_verifier_plain_sigkill_is_not_infrastructure(
+    tmp_path: Path, fake_docker: FakeClient
+) -> None:
+    container = OOMFakeContainer()
+    fake_docker.containers.container = container
+    ex = DockerToolExecutor(tmp_path, image="img")
+    outcome = _executor_runner_outcome(ex, "pytest -q", 120)
+    assert outcome.exit_code == 137
+    assert ex.oom_kill_count == 0
+    ex.close()


### PR DESCRIPTION
## Summary

Step 1 of the resource-calibration plan (Anthropic infrastructure-noise methodology, as used by Terminal-Bench 4.0). Separates the sandbox resource cap into a guaranteed floor and a hard kill ceiling, and classifies OOM kills as infrastructure errors instead of model failures.

## Changes

- `ResourceSpec` dataclass on the Docker executor: `mem_floor` -> `mem_reservation`, `cpu_floor` -> `cpu_shares` weight (soft, honest-about-Docker floors), `mem_ceiling` -> `mem_limit`, `cpu_ceiling` -> `nano_cpus`, plus `pids_limit`. Legacy kwargs still work as a floorless band; defaults unchanged.
- OOM detection gated on the container cgroup's `oom_kill` counter (v2 `memory.events`, v1 `memory.oom_control`), so `kill -9` (also exit 137) is never misclassified.
- Agent-phase OOMs: counted, surfaced to the agent as the 137 it caused, disclosed in the manifest. Verifier-phase OOMs: raise `VerifierInfrastructureError`, so the existing infra retry machinery handles them and they are never scored.
- Run manifests record `sandbox.resources` and `sandbox.oom_kills` (first-class disclosure per the methodology). New run flags: `--mem-floor --mem-ceiling --cpu-floor --cpu-ceiling --pids-limit`.

## Verification

- 18 docker-executor unit tests pass (5 new: band mapping, legacy compat, counter-gated OOM counting, verifier OOM -> infra error, plain SIGKILL -> not infra).
- Live Docker smoke: 1GB page-touching allocation under a 128m ceiling -> exit 137, `oom_killed: true`, cgroup `oom_kill 1`; plain `kill -9` -> exit 137, `oom_killed: false`.
- `tests/test_cli.py` has 2 host-PATH-dependent failures that reproduce identically on clean main (pytest unavailable outside the venv PATH); unrelated.

## Next

The calibration sweep itself (scores/durations/infra errors across resource configurations), then the agent-in-container mode for subscription CLIs (Lane A part 2) and the Harbor-format export (Lane B, in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)