### PR TITLE
Agent-in-container execution mode for the codex harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent-in-container execution mode** (`--agent-container`, codex harness
+  first): the subscription CLI runs inside a container built from the sandbox
+  base image (`make agent-image-codex`), Harbor-style, so the floor/ceiling
+  resource band bounds the agent phase as well as verification. The workspace
+  is mounted at its host path, subscription auth is a run-scoped copy of the
+  host credentials, the container (not the CLI's own Landlock sandbox, which
+  does not work under Docker) provides the write boundary, and a timeout or
+  cleanup kills the named container, not just the docker client. The
+  execution boundary is disclosed in the run summary.
+
 ### Changed
 
 - **The frontier suite directory is now `tasks/coding-intelligence-index-v4`**,

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VULCANBENCH := $(VENV_BIN)/vulcanbench
 # the venv. This makes `make ci` behave the same from any shell.
 export PATH := $(abspath $(VENV_BIN)):$(PATH)
 
-.PHONY: help setup clean install dev test lint no-emdash typecheck fmt ci docker-up docker-down validate-tasks sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-node-ts sandbox-image-go-1.26 sandbox-image-all
+.PHONY: help setup clean install dev test lint no-emdash typecheck fmt ci docker-up docker-down validate-tasks sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-node-ts sandbox-image-go-1.26 sandbox-image-all agent-image-codex
 .DEFAULT_GOAL := help
 
 help: ## Show this help
@@ -83,6 +83,10 @@ sandbox-image-go-1.26: sandbox-image ## Build Go 1.26 sandbox image (for repos w
 	@echo "✅ Built vulcanbench/sandbox:go-1.26, for Go modules newer than the base image's 1.23"
 
 sandbox-image-all: sandbox-image sandbox-image-rust sandbox-image-rust-2024 sandbox-image-node-ts sandbox-image-go-1.26 ## Build base + Rust + Node/TS + Go-1.26 sandbox images
+
+agent-image-codex: sandbox-image ## Build the containerized-agent image (Codex CLI in the sandbox base)
+	docker build -t vulcanbench/agent-codex:latest -f sandbox/Dockerfile.agent-codex .
+	@echo "✅ Built vulcanbench/agent-codex:latest for --agent-container runs"
 
 docker-up: ## Start local Postgres (see docker-compose.prod.yml for full stack)
 	docker compose up -d db

--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -27,12 +27,14 @@ as a 0.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -50,6 +52,7 @@ from harness.agent.providers import (
 )
 from harness.pricing import cost_usd
 from harness.redaction import sanitize
+from harness.sandbox.docker_executor import ResourceSpec
 
 CLI_AGENT_PROVIDERS = frozenset({"claude-code", "codex", "cursor", "grok-build", "zcode"})
 
@@ -242,6 +245,107 @@ def _subscription_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     if extra:
         env.update(extra)
     return env
+
+
+#: Default image for containerized agent execution (Harbor-style: the CLI is
+#: installed inside the container). Built by ``make agent-image-codex``.
+DEFAULT_AGENT_IMAGE = os.environ.get("VULCANBENCH_AGENT_IMAGE", "vulcanbench/agent-codex:latest")
+
+
+@dataclass(frozen=True)
+class AgentContainerSpec:
+    """How to run a subscription CLI inside a container instead of the host.
+
+    The workspace is bind-mounted at its host path so the CLI's ``--cd`` and
+    every path in the event stream stay identical to a host run. Subscription
+    auth is a run-scoped copy of the CLI's credential file, mounted read-write
+    (CLIs refresh tokens); the copy keeps a misbehaving run from corrupting
+    the host credentials. The agent phase needs the provider API, so the
+    container runs on the default network, unlike the network-off verifier.
+    """
+
+    image: str = DEFAULT_AGENT_IMAGE
+    resources: ResourceSpec | None = None
+
+
+def _agent_container_argv(
+    spec: AgentContainerSpec,
+    workspace: Path,
+    container_name: str,
+    mounts: dict[Path, str],
+    env: dict[str, str],
+) -> list[str]:
+    """The ``docker run`` prefix that wraps a CLI command for container mode."""
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "--interactive",
+        "--name",
+        container_name,
+        "--volume",
+        f"{workspace}:{workspace}",
+        "--workdir",
+        str(workspace),
+        "--security-opt",
+        "no-new-privileges",
+    ]
+    if hasattr(os, "getuid"):
+        argv += ["--user", f"{os.getuid()}:{os.getgid()}"]
+    for host_path, container_path in mounts.items():
+        argv += ["--volume", f"{host_path}:{container_path}"]
+    for key, value in env.items():
+        argv += ["--env", f"{key}={value}"]
+    resources = spec.resources
+    if resources is not None:
+        argv += [
+            "--memory",
+            resources.mem_ceiling,
+            "--cpus",
+            str(resources.cpu_ceiling),
+            "--pids-limit",
+            str(resources.pids_limit),
+        ]
+        if resources.mem_floor is not None:
+            argv += ["--memory-reservation", resources.mem_floor]
+        if resources.cpu_floor is not None:
+            argv += ["--cpu-shares", str(max(2, int(resources.cpu_floor * 1024)))]
+    argv.append(spec.image)
+    return argv
+
+
+def _kill_agent_container(container_name: str) -> None:
+    """Best-effort kill for a containerized agent (timeout/cleanup path).
+
+    Killing the ``docker run`` client process does not stop the container, so
+    a watchdog firing on the client alone would leave the agent running and
+    burning subscription quota in the background.
+    """
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            ["docker", "kill", container_name],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+
+
+def _stage_codex_auth(run_scratch: Path) -> Path:
+    """Copy the host Codex credentials into a run-scoped directory.
+
+    Only ``auth.json`` is staged: config is excluded by ``--ignore-user-config``
+    anyway, and session caches are irrelevant inside a fresh container.
+    """
+    source = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "auth.json"
+    if not source.is_file():
+        raise ProviderError(
+            f"codex credentials not found at {source}; run `codex login` on the host "
+            "before containerized execution"
+        )
+    auth_dir = run_scratch / "codex-auth"
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, auth_dir / "auth.json")
+    return auth_dir
 
 
 def _fold_usage(usage: dict[str, Any]) -> tuple[int, int]:
@@ -448,6 +552,7 @@ def run_cursor_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     cursor_bin: str = "cursor-agent",
     env_overrides: dict[str, str] | None = None,
     preflight: HarnessPreflight | None = None,
+    agent_container: AgentContainerSpec | None = None,
 ) -> CliAgentOutcome:
     """Run one task through ``cursor-agent -p`` billed to the Cursor account.
 
@@ -457,6 +562,10 @@ def run_cursor_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     ledger for what a run consumed. ``max_turns`` cannot be forwarded (no such
     flag) and ``max_run_cost`` cannot be enforced live (no streamed usage).
     """
+    if agent_container is not None:
+        raise ProviderError(
+            "agent-in-container mode currently supports only the codex harness, not cursor"
+        )
     del priced_spec, max_turns
     workspace = workspace.resolve()
     if timeout_s is not None and timeout_s <= 0:
@@ -801,6 +910,7 @@ def run_grok_build_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     grok_bin: str = "grok",
     env_overrides: dict[str, str] | None = None,
     preflight: HarnessPreflight | None = None,
+    agent_container: AgentContainerSpec | None = None,
 ) -> CliAgentOutcome:
     """Run one task through ``grok -p`` billed to the Grok subscription.
 
@@ -824,6 +934,10 @@ def run_grok_build_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     network (curl in a shell still works); web tools are removed instead and
     the audit remains the check on the rest.
     """
+    if agent_container is not None:
+        raise ProviderError(
+            "agent-in-container mode currently supports only the codex harness, not grok-build"
+        )
     workspace = workspace.resolve()
     if timeout_s is not None and timeout_s <= 0:
         raise ProviderError("run budget exhausted before CLI agent start")
@@ -1556,6 +1670,7 @@ def run_zcode_task(  # noqa: PLR0912, PLR0915, linear process + harvest
     zcode_bin: str = "zcode",
     env_overrides: dict[str, str] | None = None,
     preflight: HarnessPreflight | None = None,
+    agent_container: AgentContainerSpec | None = None,
 ) -> CliAgentOutcome:
     """Run one task through ``zcode --prompt`` billed to a GLM Coding Plan.
 
@@ -1575,6 +1690,10 @@ def run_zcode_task(  # noqa: PLR0912, PLR0915, linear process + harvest
     store after the run (see :func:`_harvest_zcode_session`), so token
     receipts exist but a live ``--max-run-cost`` cap cannot be enforced.
     """
+    if agent_container is not None:
+        raise ProviderError(
+            "agent-in-container mode currently supports only the codex harness, not zcode"
+        )
     del priced_spec, max_turns
     workspace = workspace.resolve()
     if timeout_s is not None and timeout_s <= 0:
@@ -1848,6 +1967,7 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     claude_bin: str = "claude",
     env_overrides: dict[str, str] | None = None,
     preflight: HarnessPreflight | None = None,
+    agent_container: AgentContainerSpec | None = None,
 ) -> CliAgentOutcome:
     """Run one task with Claude Code headless in ``workspace``.
 
@@ -1857,6 +1977,10 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     API cost of the streamed usage. Partial work survives a timeout or cost
     cap and is diffed/verified by the caller, mirroring the loop's semantics.
     """
+    if agent_container is not None:
+        raise ProviderError(
+            "agent-in-container mode currently supports only the codex harness, not claude-code"
+        )
     if timeout_s is not None and timeout_s <= 0:
         raise ProviderError("run budget exhausted before CLI agent start")
 
@@ -2108,8 +2232,14 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
     codex_bin: str = "codex",
     env_overrides: dict[str, str] | None = None,
     preflight: HarnessPreflight | None = None,
+    agent_container: AgentContainerSpec | None = None,
 ) -> CliAgentOutcome:
-    """Run one task through ``codex exec --json`` using ChatGPT auth."""
+    """Run one task through ``codex exec --json`` using ChatGPT auth.
+
+    With ``agent_container`` the same command runs inside a container (the
+    image ships its own codex binary); auth is a run-scoped copy of the host
+    credentials and the workspace is mounted at its host path.
+    """
     del priced_spec, max_turns
     # The subprocess also uses this directory as cwd. Passing a relative path
     # to ``--cd`` would make Codex resolve it a second time from inside itself.
@@ -2122,16 +2252,20 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
             "enforced live; use a wall-clock --timeout for subscription runs"
         )
 
-    checked = preflight or _codex_preflight(codex_bin)
+    checked = preflight or _codex_preflight("codex" if agent_container else codex_bin)
     _require_subscription(checked)
+    # In container mode the container is the sandbox (the Harbor model), and
+    # codex's own Landlock-based workspace-write sandbox does not work under
+    # Docker's seccomp profile anyway (verified live: every file write was
+    # rejected), so the CLI sandbox is disabled there.
     cmd = [
-        codex_bin,
+        "codex" if agent_container else codex_bin,
         "exec",
         "--json",
         "--ephemeral",
         "--ignore-user-config",
         "--sandbox",
-        "workspace-write",
+        "danger-full-access" if agent_container else "workspace-write",
         "--cd",
         str(workspace),
         "--model",
@@ -2139,9 +2273,29 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
     ]
     if effort:
         cmd += ["--config", f'model_reasoning_effort="{effort}"']
-    if network:
+    if network and agent_container is None:
         cmd += ["--config", "sandbox_workspace_write.network_access=true"]
     cmd.append("-")
+
+    container_name: str | None = None
+    if agent_container is not None:
+        container_name = f"vb-agent-{uuid.uuid4().hex[:12]}"
+        scratch = (
+            stream_log_path.parent
+            if stream_log_path is not None
+            else Path(tempfile.mkdtemp(prefix="vb-agent-"))
+        )
+        auth_dir = _stage_codex_auth(scratch)
+        cmd = (
+            _agent_container_argv(
+                agent_container,
+                workspace,
+                container_name,
+                mounts={auth_dir: "/codex-auth"},
+                env={"CODEX_HOME": "/codex-auth", "HOME": "/tmp"},
+            )
+            + cmd
+        )
 
     collector.record(
         "cli_agent_start",
@@ -2149,6 +2303,11 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
             "harness": "codex",
             "argv": [*cmd[:-1], "<prompt via stdin>"],
             "harness_version": checked.version,
+            "agent_container": (
+                {"image": agent_container.image, "name": container_name}
+                if agent_container
+                else None
+            ),
         },
     )
     try:
@@ -2183,7 +2342,12 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
     stderr_thread.start()
     outcome = CliAgentOutcome(
         harness="codex",
-        execution_boundary="host-workspace; sandbox=workspace-write",
+        execution_boundary=(
+            f"container-workspace; sandbox=container (CLI sandbox off); "
+            f"image={agent_container.image}"
+            if agent_container
+            else "host-workspace; sandbox=workspace-write"
+        ),
         requested_model=model,
         harness_version=checked.version,
         auth_method=checked.auth_mode,
@@ -2193,6 +2357,9 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
 
     def _kill_on_timeout() -> None:
         killed["timeout"] = True
+        if container_name is not None:
+            # Killing the docker client alone leaves the container running.
+            _kill_agent_container(container_name)
         proc.kill()
 
     watchdog: threading.Timer | None = None
@@ -2249,6 +2416,8 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
             watchdog.cancel()
         if stream_f:
             stream_f.close()
+        if container_name is not None:
+            _kill_agent_container(container_name)
 
     proc.wait()
     stderr_thread.join(timeout=5)

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from harness.agent.cli_agents import (
+    AgentContainerSpec,
     CliAgentAdapter,
     CliAgentOutcome,
     build_cli_prompt,
@@ -157,6 +158,7 @@ def run_agent(  # noqa: PLR0915
     max_run_cost: float | None = None,
     override_budgets: bool = False,
     resources: ResourceSpec | None = None,
+    agent_container: bool = False,
 ) -> dict[str, Any]:
     """Run one evaluation: agent solves ``task_id`` with ``model``.
 
@@ -226,6 +228,9 @@ def run_agent(  # noqa: PLR0915
                 effort_meta=effort_meta,
                 network=network,
                 max_run_cost=max_run_cost,
+                agent_container_spec=(
+                    AgentContainerSpec(resources=resources) if agent_container else None
+                ),
             )
         )
         patch = _git_diff(workspace)
@@ -442,6 +447,7 @@ def _execute_agent(
     effort_meta: Any,
     network: bool,
     max_run_cost: float | None,
+    agent_container_spec: AgentContainerSpec | None = None,
 ) -> tuple[int, int, bool, bool, int, CliAgentOutcome | None]:
     """Run the agent phase: the vendor CLI in the workspace, or the model loop."""
     if cli_adapter is not None:
@@ -458,6 +464,7 @@ def _execute_agent(
             network=network,
             max_run_cost=max_run_cost,
             effort=effort_meta.provider_value if effort_meta and effort_meta.supported else None,
+            agent_container=agent_container_spec,
         )
         if outcome.timed_out:
             deadline.record_exceeded(collector, "cli_agent")

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -246,6 +246,13 @@ def run(  # noqa: PLR0912, PLR0915, CLI entry: option declarations + linear guar
         2.0, "--cpu-ceiling", help="Hard sandbox CPU cap (docker nano_cpus)"
     ),
     pids_limit: int = typer.Option(512, "--pids-limit", help="Hard sandbox process-count cap"),
+    agent_container: bool = typer.Option(
+        False,
+        "--agent-container/--no-agent-container",
+        help="Run the subscription CLI agent inside a container (codex only for "
+        "now): Harbor-style execution with the resource band applied to the "
+        "agent phase too. Requires the vulcanbench/agent-codex image.",
+    ),
     repeat: int = typer.Option(1, "--repeat", help="Run each task N times (for pass@k / stderr)"),
     max_concurrency: int = typer.Option(
         1, "--max-concurrency", help="Run suite tasks in parallel (suite runs only)"
@@ -385,6 +392,7 @@ def run(  # noqa: PLR0912, PLR0915, CLI entry: option declarations + linear guar
         "effort": effort,
         "max_run_cost": max_run_cost,
         "override_budgets": override_budgets,
+        "agent_container": agent_container,
         "resources": ResourceSpec(
             mem_floor=mem_floor,
             mem_ceiling=mem_ceiling,

--- a/sandbox/Dockerfile.agent-codex
+++ b/sandbox/Dockerfile.agent-codex
@@ -1,0 +1,23 @@
+# VulcanBench containerized-agent image: Codex CLI.
+#
+# Build:  make agent-image-codex
+# Use:    vulcanbench run --task <id> --model codex:<model> --sandbox docker --agent-container
+#
+# Harbor-style execution: the subscription CLI runs INSIDE this container
+# instead of on the host, so the resource band (floor/ceiling) bounds the
+# agent phase too, not just verification. Extends the sandbox base image so
+# the agent has the same toolchains verification uses. Subscription auth is
+# mounted at /codex-auth by the harness (CODEX_HOME), never baked in.
+#
+# The Codex CLI version is pinned to match the host installation the program's
+# existing measurements used; bump both together.
+FROM vulcanbench/sandbox:base
+
+ARG CODEX_VERSION=0.149.0
+
+RUN npm install -g @openai/codex@${CODEX_VERSION} \
+    && codex --version
+
+# The harness runs the container as the host UID with HOME=/tmp; nothing else
+# to prepare. Network stays enabled at run time (the agent phase needs the
+# provider API); the verifier runs in a separate network-off container.

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -19,7 +19,10 @@ import pytest
 from harness.agent import loop as loop_mod
 from harness.agent.cli_agents import (
     _ZCODE_LIMIT_PATTERN,
+    AgentContainerSpec,
     SubscriptionQuotaError,
+    _agent_container_argv,
+    _stage_codex_auth,
     _subscription_env,
     _zcode_preflight,
     _zcode_session_limit_error,
@@ -27,12 +30,13 @@ from harness.agent.cli_agents import (
     run_claude_code_task,
     run_codex_task,
     run_cursor_task,
+    run_grok_build_task,
     run_zcode_task,
 )
 from harness.agent.loop import _resolve_run_engine, run_agent
 from harness.agent.providers import ProviderError, get_provider
 from harness.pricing import cost_usd, is_priced
-from harness.sandbox.docker_executor import SandboxError
+from harness.sandbox.docker_executor import ResourceSpec, SandboxError
 
 # Result usage: 150 uncached + 50 cache-read (0.1x) + 10 cache-write (1.25x)
 # folds to round(167.5) = 168 effective prompt tokens.
@@ -1042,3 +1046,66 @@ def test_subscription_env_blocks_system_pip_installs() -> None:
     assert env["PYTHONNOUSERSITE"] == "1"
     # Test adapters may still override explicitly.
     assert _subscription_env({"PIP_REQUIRE_VIRTUALENV": "0"})["PIP_REQUIRE_VIRTUALENV"] == "0"
+
+
+# --- agent-in-container mode --------------------------------------------------
+
+
+def test_agent_container_argv_wraps_command_with_band() -> None:
+    spec = AgentContainerSpec(
+        image="vulcanbench/agent-codex:latest",
+        resources=ResourceSpec(
+            mem_floor="1g", mem_ceiling="4g", cpu_floor=1.0, cpu_ceiling=3.0, pids_limit=1024
+        ),
+    )
+    argv = _agent_container_argv(
+        spec,
+        Path("/tmp/ws"),
+        "vb-agent-test",
+        mounts={Path("/tmp/auth"): "/codex-auth"},
+        env={"CODEX_HOME": "/codex-auth", "HOME": "/tmp"},
+    )
+    assert argv[:3] == ["docker", "run", "--rm"]
+    assert "--interactive" in argv
+    joined = " ".join(argv)
+    assert "--volume /tmp/ws:/tmp/ws" in joined
+    assert "--workdir /tmp/ws" in joined
+    assert "--volume /tmp/auth:/codex-auth" in joined
+    assert "--env CODEX_HOME=/codex-auth" in joined
+    assert "--memory 4g" in joined
+    assert "--memory-reservation 1g" in joined
+    assert "--cpus 3.0" in joined
+    assert "--cpu-shares 1024" in joined
+    assert "--pids-limit 1024" in joined
+    assert "no-new-privileges" in joined
+    assert argv[-1] == "vulcanbench/agent-codex:latest"
+
+
+def test_agent_container_rejected_by_non_codex_harnesses(tmp_path: Path) -> None:
+    spec = AgentContainerSpec()
+    for runner in (run_claude_code_task, run_cursor_task, run_grok_build_task, run_zcode_task):
+        with pytest.raises(ProviderError, match="only the codex harness"):
+            runner(
+                workspace=tmp_path,
+                prompt="p",
+                model="m",
+                priced_spec="s",
+                max_turns=1,
+                collector=_Collector(),
+                agent_container=spec,
+            )
+
+
+def test_stage_codex_auth_requires_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "nope"))
+    with pytest.raises(ProviderError, match="codex login"):
+        _stage_codex_auth(tmp_path / "scratch")
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text('{"token": "t"}')
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    staged = _stage_codex_auth(tmp_path / "scratch2")
+    assert (staged / "auth.json").read_text() == '{"token": "t"}'


### PR DESCRIPTION
## Summary

Lane A part 2: `vulcanbench run --model codex:<m> --sandbox docker --agent-container` now runs the Codex CLI inside a container built from the sandbox base (`make agent-image-codex`), the Harbor execution model. The resource band from PR #100 then bounds the agent phase as well as verification, which is what makes the infrastructure-noise calibration meaningful for subscription columns.

## Design points

- Workspace bind-mounted at its host path, so `--cd` and every path in the event stream are identical to host runs; container runs as the host UID.
- Subscription auth is a run-scoped copy of `auth.json` mounted at `CODEX_HOME`: host credentials cannot be corrupted, nothing is baked into the image, and the economics receipts still see subscription billing.
- The container is the sandbox: codex's own Landlock workspace-write sandbox does not work under Docker's seccomp profile (verified live, every write rejected), so container mode disables the CLI sandbox and relies on the container boundary. Disclosed in `execution_boundary`.
- Timeout/cleanup kill the named container, not just the docker client (the client dying alone leaves the agent running and burning quota).
- Codex only for now; the other four harnesses reject the flag with a clear error.

## Verification

- Live end-to-end smoke: containerized codex (image pins CLI 0.149.0, matching the host) created the requested file with correct content and host-user ownership, subscription-authenticated, full event stream parsed, inside a 2g/2cpu band.
- 57 adapter + executor unit tests pass (new: docker argv construction with the full band, non-codex rejection, auth staging including the missing-credentials error).
- Known limitation, disclosed: the image is amd64 (matching the sandbox image policy) and runs emulated on Apple Silicon; effort-axis durations measured in this mode are not comparable to host-run numbers until we build arm64 task binaries or run on native amd64 hosts. That comparison is exactly what the calibration sweep will quantify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)