### PR TITLE
Resolve the staged codex auth dir to an absolute path before mounting

### DIFF
--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -342,7 +342,9 @@ def _stage_codex_auth(run_scratch: Path) -> Path:
             f"codex credentials not found at {source}; run `codex login` on the host "
             "before containerized execution"
         )
-    auth_dir = run_scratch / "codex-auth"
+    # Docker bind mounts need absolute host paths; run dirs are usually
+    # relative (./runs/<id>), which docker rejects as a volume name.
+    auth_dir = (run_scratch / "codex-auth").resolve()
     auth_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, auth_dir / "auth.json")
     return auth_dir

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -1109,3 +1109,16 @@ def test_stage_codex_auth_requires_credentials(
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
     staged = _stage_codex_auth(tmp_path / "scratch2")
     assert (staged / "auth.json").read_text() == '{"token": "t"}'
+
+
+def test_stage_codex_auth_returns_absolute_path_for_relative_scratch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Docker rejects relative bind-mount sources; run dirs are usually ./runs/<id>."""
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.chdir(tmp_path)
+    staged = _stage_codex_auth(Path("runs") / "some-run")
+    assert staged.is_absolute()


### PR DESCRIPTION
First real --agent-container run (relative ./runs output dir) failed: docker rejects relative bind-mount sources. The verification smoke had used an absolute tempdir and missed the case. One-line resolve() plus a regression test that stages from a relative scratch dir and asserts the returned mount source is absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)