### PR TITLE
Claude Code agent-in-container mode with credential write-back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ agent-image-codex: sandbox-image ## Build the containerized-agent image (Codex C
 	docker build -t vulcanbench/agent-codex:latest -f sandbox/Dockerfile.agent-codex .
 	@echo "✅ Built vulcanbench/agent-codex:latest for --agent-container runs"
 
+agent-image-claude-code: sandbox-image ## Build the containerized-agent image (Claude Code CLI in the sandbox base)
+	docker build -t vulcanbench/agent-claude-code:latest -f sandbox/Dockerfile.agent-claude-code .
+	@echo "✅ Built vulcanbench/agent-claude-code:latest for --agent-container runs"
+
 docker-up: ## Start local Postgres (see docker-compose.prod.yml for full stack)
 	docker compose up -d db
 

--- a/harness/agent/cli_agents.py
+++ b/harness/agent/cli_agents.py
@@ -251,6 +251,31 @@ def _subscription_env(extra: dict[str, str] | None = None) -> dict[str, str]:
 #: installed inside the container). Built by ``make agent-image-codex``.
 DEFAULT_AGENT_IMAGE = os.environ.get("VULCANBENCH_AGENT_IMAGE", "vulcanbench/agent-codex:latest")
 
+#: Per-harness agent images (``make agent-image-<harness>``). The
+#: VULCANBENCH_AGENT_IMAGE env override wins for every harness.
+_AGENT_IMAGES = {
+    "codex": "vulcanbench/agent-codex:latest",
+    "claude-code": "vulcanbench/agent-claude-code:latest",
+}
+
+
+def default_agent_image(harness_id: str) -> str:
+    """The containerized-agent image for ``harness_id``.
+
+    Raises for harnesses without a container image so the failure is a clear
+    configuration error instead of a docker pull of a nonexistent tag.
+    """
+    override = os.environ.get("VULCANBENCH_AGENT_IMAGE")
+    if override:
+        return override
+    image = _AGENT_IMAGES.get(harness_id)
+    if image is None:
+        raise ProviderError(
+            f"agent-in-container mode has no image for harness {harness_id!r}; "
+            f"supported: {', '.join(sorted(_AGENT_IMAGES))}"
+        )
+    return image
+
 
 @dataclass(frozen=True)
 class AgentContainerSpec:
@@ -348,6 +373,108 @@ def _stage_codex_auth(run_scratch: Path) -> Path:
     auth_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, auth_dir / "auth.json")
     return auth_dir
+
+
+def _stage_claude_code_auth(run_scratch: Path) -> Path:
+    """Stage the host Claude Code subscription credentials for a container.
+
+    A Linux container reads ``.credentials.json`` from the config dir; macOS
+    hosts keep the same OAuth JSON in the Keychain instead, so it is extracted
+    with ``security``. A minimal ``.claude.json`` marks onboarding complete so
+    headless startup never blocks on a first-run prompt. Run-scoped copy for
+    the same reason as codex: a misbehaving run cannot corrupt host auth.
+    """
+    config_home = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
+    file_source = config_home / ".credentials.json"
+    if file_source.is_file():
+        credentials = file_source.read_text(encoding="utf-8")
+    else:
+        try:
+            proc = subprocess.run(
+                ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            proc = None
+        credentials = proc.stdout.strip() if proc and proc.returncode == 0 else ""
+        if not credentials:
+            raise ProviderError(
+                "Claude Code credentials not found (no .credentials.json and no "
+                "Keychain entry); sign in by running `claude` on the host before "
+                "containerized execution"
+            )
+    auth_dir = (run_scratch / "claude-code-auth").resolve()
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    credentials_path = auth_dir / ".credentials.json"
+    credentials_path.write_text(credentials, encoding="utf-8")
+    credentials_path.chmod(0o600)
+    (auth_dir / ".claude.json").write_text(
+        json.dumps({"hasCompletedOnboarding": True}), encoding="utf-8"
+    )
+    return auth_dir
+
+
+def _sync_codex_auth_back(auth_dir: Path) -> None:
+    """Persist refreshed tokens from the run-scoped copy back to the host.
+
+    OAuth refresh tokens rotate: when a containerized run refreshes, the only
+    valid refresh token lives in the staged copy, and discarding it bricks
+    host auth (observed live with claude-code; the same hazard applies here).
+    Best-effort by design: auth sync must never fail a finished run.
+    """
+    with contextlib.suppress(Exception):
+        staged = auth_dir / "auth.json"
+        source = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "auth.json"
+        if staged.is_file() and source.is_file() and staged.read_bytes() != source.read_bytes():
+            shutil.copy2(staged, source)
+
+
+def _sync_claude_code_auth_back(auth_dir: Path, staged_original: str) -> None:
+    """Claude Code variant of :func:`_sync_codex_auth_back`.
+
+    The host store is either ``.credentials.json`` (Linux) or the macOS
+    Keychain entry the credentials were originally extracted from.
+    """
+    with contextlib.suppress(Exception):
+        staged = auth_dir / ".credentials.json"
+        if not staged.is_file():
+            return
+        current = staged.read_text(encoding="utf-8")
+        if current.strip() == staged_original.strip():
+            return
+        config_home = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
+        file_source = config_home / ".credentials.json"
+        if file_source.is_file():
+            file_source.write_text(current, encoding="utf-8")
+            return
+        lookup = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        match = re.search(r'"acct"<blob>="([^"]*)"', lookup.stdout + lookup.stderr)
+        if match:
+            subprocess.run(
+                [
+                    "security",
+                    "add-generic-password",
+                    "-U",
+                    "-s",
+                    "Claude Code-credentials",
+                    "-a",
+                    match.group(1),
+                    "-w",
+                    current,
+                ],
+                capture_output=True,
+                timeout=30,
+                check=False,
+            )
 
 
 def _fold_usage(usage: dict[str, Any]) -> tuple[int, int]:
@@ -1979,18 +2106,20 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     API cost of the streamed usage. Partial work survives a timeout or cost
     cap and is diffed/verified by the caller, mirroring the loop's semantics.
     """
-    if agent_container is not None:
-        raise ProviderError(
-            "agent-in-container mode currently supports only the codex harness, not claude-code"
-        )
     if timeout_s is not None and timeout_s <= 0:
         raise ProviderError("run budget exhausted before CLI agent start")
 
-    checked = preflight or _claude_preflight(claude_bin)
+    checked = preflight or _claude_preflight("claude" if agent_container else claude_bin)
     _require_subscription(checked)
 
+    # In container mode the container is the write boundary and Claude Code's
+    # own sandboxing is off: --safe-mode's backend needs privileges Docker's
+    # default profile does not grant, and --permission-mode auto only
+    # auto-grants inside that sandbox (verified live: without it, the first
+    # Write blocked on a permission request). So the container runs with
+    # permissions bypassed, the Harbor model. Disclosed in the boundary.
     cmd = [
-        claude_bin,
+        "claude" if agent_container else claude_bin,
         "-p",
         prompt,
         "--output-format",
@@ -2000,9 +2129,11 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
         model,
         "--max-turns",
         str(max_turns),
-        "--permission-mode",
-        "auto",
-        "--safe-mode",
+        *(
+            ["--dangerously-skip-permissions"]
+            if agent_container
+            else ["--permission-mode", "auto", "--safe-mode"]
+        ),
         "--no-session-persistence",
         # Hermetic runs: don't let the operator's user-level config/memory
         # leak instructions into the benchmark.
@@ -2014,9 +2145,40 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
     if not network:
         cmd += ["--disallowedTools", _WEB_TOOLS]
 
+    container_name: str | None = None
+    auth_dir: Path | None = None
+    staged_original = ""
+    if agent_container is not None:
+        container_name = f"vb-agent-{uuid.uuid4().hex[:12]}"
+        scratch = (
+            stream_log_path.parent
+            if stream_log_path is not None
+            else Path(tempfile.mkdtemp(prefix="vb-agent-"))
+        )
+        auth_dir = _stage_claude_code_auth(scratch)
+        staged_original = (auth_dir / ".credentials.json").read_text(encoding="utf-8")
+        cmd = (
+            _agent_container_argv(
+                agent_container,
+                workspace.resolve(),
+                container_name,
+                mounts={auth_dir: "/claude-config"},
+                env={"CLAUDE_CONFIG_DIR": "/claude-config", "HOME": "/tmp"},
+            )
+            + cmd
+        )
+
     collector.record(
         "cli_agent_start",
-        {"harness": "claude-code", "argv": [cmd[0], "-p", "<prompt omitted>", *cmd[3:]]},
+        {
+            "harness": "claude-code",
+            "argv": [cmd[0], "-p", "<prompt omitted>", *cmd[3:]],
+            "agent_container": (
+                {"image": agent_container.image, "name": container_name}
+                if agent_container
+                else None
+            ),
+        },
     )
 
     try:
@@ -2048,7 +2210,12 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
 
     outcome = CliAgentOutcome(
         harness="claude-code",
-        execution_boundary="host-workspace; permission-mode=auto; safe-mode",
+        execution_boundary=(
+            f"container-workspace; permissions=bypass (container is the "
+            f"sandbox); image={agent_container.image}"
+            if agent_container
+            else "host-workspace; permission-mode=auto; safe-mode"
+        ),
         requested_model=model,
         harness_version=checked.version,
         auth_method=checked.auth_mode,
@@ -2058,6 +2225,9 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
 
     def _kill_on_timeout() -> None:
         killed["timeout"] = True
+        if container_name is not None:
+            # Killing the docker client alone leaves the container running.
+            _kill_agent_container(container_name)
         proc.kill()
 
     watchdog: threading.Timer | None = None
@@ -2135,6 +2305,10 @@ def run_claude_code_task(  # noqa: PLR0912, PLR0915, linear stream-parse loop
             watchdog.cancel()
         if stream_f:
             stream_f.close()
+        if container_name is not None:
+            _kill_agent_container(container_name)
+        if auth_dir is not None:
+            _sync_claude_code_auth_back(auth_dir, staged_original)
 
     proc.wait()
     stderr_thread.join(timeout=5)
@@ -2280,6 +2454,7 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
     cmd.append("-")
 
     container_name: str | None = None
+    auth_dir: Path | None = None
     if agent_container is not None:
         container_name = f"vb-agent-{uuid.uuid4().hex[:12]}"
         scratch = (
@@ -2420,6 +2595,8 @@ def run_codex_task(  # noqa: PLR0912, PLR0915, linear process/stream adapter
             stream_f.close()
         if container_name is not None:
             _kill_agent_container(container_name)
+        if auth_dir is not None:
+            _sync_codex_auth_back(auth_dir)
 
     proc.wait()
     stderr_thread.join(timeout=5)

--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -33,6 +33,7 @@ from harness.agent.cli_agents import (
     CliAgentAdapter,
     CliAgentOutcome,
     build_cli_prompt,
+    default_agent_image,
     get_cli_agent_adapter,
     is_cli_agent_spec,
 )
@@ -172,7 +173,15 @@ def run_agent(  # noqa: PLR0915
     summary dict (also persisted to ``<run_dir>/summary.json``).
     """
     task = load_task(task_id, tasks_root)
-    cli_adapter, provider, effort_meta = _resolve_run_engine(model, provider, effort, sandbox)
+    cli_adapter, provider, effort_meta = _resolve_run_engine(
+        model, provider, effort, sandbox, agent_container
+    )
+    if agent_container and cli_adapter is None:
+        raise SandboxError(
+            "--agent-container applies to subscription CLI harnesses "
+            "(codex:, claude-code:); API-loop runs are already containerized "
+            "by --sandbox docker"
+        )
     effective_max_steps = resolve_max_steps(task.metadata, max_steps, override=override_budgets)
     effective_timeout = resolve_agent_timeout_s(task.metadata, timeout_s, override=override_budgets)
 
@@ -229,7 +238,12 @@ def run_agent(  # noqa: PLR0915
                 network=network,
                 max_run_cost=max_run_cost,
                 agent_container_spec=(
-                    AgentContainerSpec(resources=resources) if agent_container else None
+                    AgentContainerSpec(
+                        image=default_agent_image(cli_adapter.harness_id),
+                        resources=resources,
+                    )
+                    if agent_container and cli_adapter is not None
+                    else None
                 ),
             )
         )
@@ -401,6 +415,7 @@ def _resolve_run_engine(
     provider: LLMProvider | None,
     effort: str | None,
     sandbox: str,
+    agent_container: bool = False,
 ) -> tuple[CliAgentAdapter | None, LLMProvider | None, Any]:
     """Decide whether ``model`` runs as a vendor agent CLI or via a provider.
 
@@ -418,11 +433,14 @@ def _resolve_run_engine(
         # the same directory. Forcing Cursor to local also forced the VERIFIER
         # to the host, where toolchains don't match the sandbox image, every
         # Python task failed verification with "pytest is unavailable".
-        if adapter.harness_id == "claude-code" and sandbox != "local":
+        # With --agent-container the CLI executes inside a container, so the
+        # host-execution acknowledgment no longer applies and --sandbox docker
+        # is the natural pairing (verifier in its own network-off container).
+        if adapter.harness_id == "claude-code" and sandbox != "local" and not agent_container:
             raise SandboxError(
                 f"model spec {model!r} runs a vendor agent CLI on the host with "
                 "its own tool execution; pass --sandbox local to acknowledge "
-                "host execution"
+                "host execution, or --agent-container to run it in a container"
             )
         return adapter, None, effort_config(adapter.harness_id, effort)
     provider = provider or get_provider(model)
@@ -465,7 +483,7 @@ def _execute_agent(
             max_run_cost=max_run_cost,
             effort=effort_meta.provider_value if effort_meta and effort_meta.supported else None,
             agent_container=agent_container_spec,
-        )
+        )  # spec is built per harness by the caller (image + resource band)
         if outcome.timed_out:
             deadline.record_exceeded(collector, "cli_agent")
         return (

--- a/sandbox/Dockerfile.agent-claude-code
+++ b/sandbox/Dockerfile.agent-claude-code
@@ -1,0 +1,19 @@
+# VulcanBench containerized-agent image: Claude Code CLI.
+#
+# Build:  make agent-image-claude-code
+# Use:    vulcanbench run --task <id> --model claude-code:<model> --sandbox docker --agent-container
+#
+# Harbor-style execution: the subscription CLI runs INSIDE this container.
+# Extends the sandbox base image so the agent has the same toolchains
+# verification uses. Subscription auth is staged by the harness (macOS
+# Keychain extraction into .credentials.json) and mounted at /claude-config
+# via CLAUDE_CONFIG_DIR; never baked in.
+#
+# Pinned to the host installation's version so container and host columns
+# stay attributable; bump both together.
+FROM vulcanbench/sandbox:base
+
+ARG CLAUDE_CODE_VERSION=2.1.247
+
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    && claude --version

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -22,10 +22,14 @@ from harness.agent.cli_agents import (
     AgentContainerSpec,
     SubscriptionQuotaError,
     _agent_container_argv,
+    _stage_claude_code_auth,
     _stage_codex_auth,
     _subscription_env,
+    _sync_claude_code_auth_back,
+    _sync_codex_auth_back,
     _zcode_preflight,
     _zcode_session_limit_error,
+    default_agent_image,
     is_cli_agent_spec,
     run_claude_code_task,
     run_codex_task,
@@ -1083,7 +1087,7 @@ def test_agent_container_argv_wraps_command_with_band() -> None:
 
 def test_agent_container_rejected_by_non_codex_harnesses(tmp_path: Path) -> None:
     spec = AgentContainerSpec()
-    for runner in (run_claude_code_task, run_cursor_task, run_grok_build_task, run_zcode_task):
+    for runner in (run_cursor_task, run_grok_build_task, run_zcode_task):
         with pytest.raises(ProviderError, match="only the codex harness"):
             runner(
                 workspace=tmp_path,
@@ -1122,3 +1126,61 @@ def test_stage_codex_auth_returns_absolute_path_for_relative_scratch(
     monkeypatch.chdir(tmp_path)
     staged = _stage_codex_auth(Path("runs") / "some-run")
     assert staged.is_absolute()
+
+
+def test_stage_claude_code_auth_from_credentials_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_home = tmp_path / "claude-home"
+    config_home.mkdir()
+    (config_home / ".credentials.json").write_text('{"claudeAiOauth": {"a": 1}}')
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_home))
+    staged = _stage_claude_code_auth(tmp_path / "scratch")
+    assert staged.is_absolute()
+    assert (staged / ".credentials.json").read_text() == '{"claudeAiOauth": {"a": 1}}'
+    assert json.loads((staged / ".claude.json").read_text())["hasCompletedOnboarding"] is True
+
+
+def test_default_agent_image_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VULCANBENCH_AGENT_IMAGE", raising=False)
+    assert default_agent_image("codex") == "vulcanbench/agent-codex:latest"
+    assert default_agent_image("claude-code") == "vulcanbench/agent-claude-code:latest"
+    with pytest.raises(ProviderError, match="no image for harness"):
+        default_agent_image("cursor")
+    monkeypatch.setenv("VULCANBENCH_AGENT_IMAGE", "custom:tag")
+    assert default_agent_image("cursor") == "custom:tag"
+
+
+def test_sync_codex_auth_back_copies_changed_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text('{"token": "old"}')
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    staged = _stage_codex_auth(tmp_path / "scratch")
+    # No refresh: host untouched.
+    _sync_codex_auth_back(staged)
+    assert (codex_home / "auth.json").read_text() == '{"token": "old"}'
+    # The container refreshed (rotating the refresh token): host must follow.
+    (staged / "auth.json").write_text('{"token": "rotated"}')
+    _sync_codex_auth_back(staged)
+    assert (codex_home / "auth.json").read_text() == '{"token": "rotated"}'
+
+
+def test_sync_claude_code_auth_back_file_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_home = tmp_path / "claude-home"
+    config_home.mkdir()
+    (config_home / ".credentials.json").write_text('{"claudeAiOauth": {"v": 1}}')
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_home))
+    staged = _stage_claude_code_auth(tmp_path / "scratch")
+    original = (staged / ".credentials.json").read_text()
+    # Unchanged: host untouched (and no keychain lookup attempted).
+    _sync_claude_code_auth_back(staged, original)
+    assert (config_home / ".credentials.json").read_text() == '{"claudeAiOauth": {"v": 1}}'
+    # Refreshed in-container: host file must follow.
+    (staged / ".credentials.json").write_text('{"claudeAiOauth": {"v": 2}}')
+    _sync_claude_code_auth_back(staged, original)
+    assert (config_home / ".credentials.json").read_text() == '{"claudeAiOauth": {"v": 2}}'


### PR DESCRIPTION
## Summary

Extends `--agent-container` (PR #102) from codex to claude-code, the prerequisite for standardizing containerized agent execution in CII v4 v3.0 per the adopted plan.

## The hard-won part: credential write-back

OAuth refresh tokens rotate. A containerized run that refreshes writes the new tokens into the run-scoped staged copy; discarding that copy strands the only valid refresh token and breaks HOST auth. This actually happened during verification (host Claude Code went to "OAuth session expired and could not be refreshed"); recovery was restoring the staged copy's refreshed tokens to the Keychain. Both codex and claude-code runners now sync changed credentials back to the host store (auth.json file, .credentials.json file, or macOS Keychain via `security -U`) in their cleanup path, best-effort so auth sync can never fail a finished run.

## Other design points

- macOS auth staging: Claude Code stores subscription OAuth in the Keychain, extracted with `security` into the `.credentials.json` a Linux container expects, mounted at `CLAUDE_CONFIG_DIR`.
- Container permissions: `--permission-mode auto` only auto-grants inside `--safe-mode`'s sandbox, which cannot run under Docker's default profile (verified live: the first Write blocked on a permission request). Container mode uses the permission bypass, the Harbor model; the container is the boundary, disclosed in `execution_boundary`.
- The `claude-code requires --sandbox local` guard is relaxed when `--agent-container` is set; `--agent-container` on a non-CLI model spec errors clearly.
- Per-harness image mapping (`vulcanbench/agent-claude-code:latest`, CLI pinned to 2.1.247 matching the host); `make agent-image-claude-code`.

## Verification

- Live end-to-end containerized claude-code run (haiku, trivial task): file created with host-user ownership, subscription auth (max plan), host Keychain credentials verified unchanged afterward, and a follow-up host run still authenticates.
- 62 adapter + executor unit tests pass (new: keychain/file staging, write-back for both harnesses, per-harness image mapping, guard behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)