### PR TITLE
Never length-cap final.patch: sanitize()'s field cap corrupted large patches

### DIFF
--- a/harness/agent/loop.py
+++ b/harness/agent/loop.py
@@ -48,7 +48,7 @@ from harness.evaluator.evaluate import evaluate_run
 from harness.evaluator.scorer import run_verifier, score_run
 from harness.persistence import maybe_post_run_summary
 from harness.pricing import cost_usd, has_cached_input_price, is_priced
-from harness.redaction import sanitize
+from harness.redaction import redact
 from harness.sandbox.docker_executor import (
     DockerToolExecutor,
     ResourceSpec,
@@ -249,8 +249,12 @@ def run_agent(  # noqa: PLR0915
         )
         patch = _git_diff(workspace)
         changed_files = _git_changed_files(workspace)
-        # Sanitize the published patch artifact (defense-in-depth; trace is sanitized too).
-        (run_dir / "final.patch").write_text(str(sanitize(patch)), encoding="utf-8")
+        # Redact the published patch artifact (defense-in-depth; trace is
+        # sanitized too) but NEVER length-cap it: sanitize()'s field cap
+        # truncated a >20k-char patch into a corrupt diff, which silently
+        # broke regrade for that run (found live on a Fable 5.1 settlecore
+        # rewrite). The patch is an integrity artifact, not a display field.
+        (run_dir / "final.patch").write_text(redact(patch), encoding="utf-8")
         collector.record("diff", {"patch": patch})
 
         functional, verifier_payload = _verify_with_budget(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -237,7 +237,7 @@ def test_run_agent_budget_expiring_during_provider_does_not_finish(
     assert "test_result" not in types
 
 
-def test_final_patch_is_redacted_and_capped(
+def test_final_patch_is_redacted_but_never_truncated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     secret = "ghp_" + "A" * 40
@@ -271,8 +271,10 @@ def test_final_patch_is_redacted_and_capped(
     patch = (tmp_path / res["run_id"] / "final.patch").read_text(encoding="utf-8")
     assert secret not in patch
     assert "[REDACTED]" in patch
-    assert "truncated" in patch
-    assert len(patch) <= MAX_FIELD_CHARS + 80
+    # Redacted but NEVER truncated: capping corrupted >20k-char patches into
+    # unappliable diffs and silently broke regrade (Fable 5.1 settlecore).
+    assert "truncated" not in patch
+    assert len(patch) > MAX_FIELD_CHARS
 
 
 def test_execute_tool_caps_run_command_timeout_to_remaining_budget() -> None:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -96,3 +96,13 @@ def test_sanitize_recurses_and_caps() -> None:
     assert out["list"][0] == REDACTED
     assert out["list"][1] == 42  # non-strings pass through
     assert out["list"][2] is None
+
+
+def test_redact_never_truncates_large_text() -> None:
+    """final.patch is written via redact(), not sanitize(): a >20k-char agent
+    patch must survive byte-for-byte (a sanitize() field-cap once corrupted a
+    Fable 5.1 settlecore rewrite into an unappliable diff, silently breaking
+    regrade for that run)."""
+    big = "x" * (MAX_FIELD_CHARS * 3)
+    assert redact(big) == big
+    assert "truncated" in sanitize(big)


### PR DESCRIPTION
The agent patch artifact went through sanitize(), whose 20k-char field cap turned any large patch into a corrupt diff (literal truncation marker in the file). Live verification never noticed (it grades the workspace, not the patch), but regrade replays final.patch, so regrading a large-patch run silently applied nothing and scored the naive base: honest solves rescored as 0.0.

Found live: Fable 5.1's settlecore and paddockcore rewrites both exceeded the cap; their regrades came back 0.0 while the archived workspaces passed every hidden test by hand. Patches were recovered from the archived workspaces (git diff HEAD) and regraded correctly after this fix (settlecore 1.0, paddockcore 1.0).

Fix: write final.patch via redact() (secret redaction, no length cap). Regression test pins redact-vs-sanitize behavior at 3x the cap.

Also worth knowing for auditing: any historical run whose final.patch ends in "[truncated N chars]" has a corrupt patch artifact; the archived workspace remains the ground truth and the patch can be regenerated from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)